### PR TITLE
Clean up linting issues and improve code quality

### DIFF
--- a/lib/benchling-webhook-stack.ts
+++ b/lib/benchling-webhook-stack.ts
@@ -1,9 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as events from "aws-cdk-lib/aws-events";
-import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as nodejs from "aws-cdk-lib/aws-lambda-nodejs";
-import * as path from "path";
 import { Construct } from "constructs";
 import { WebhookApi } from "./api-gateway";
 import { WebhookStateMachine } from "./webhook-state-machine";

--- a/lib/packaging-state-machine.ts
+++ b/lib/packaging-state-machine.ts
@@ -5,14 +5,12 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as nodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as path from "path";
 import * as tasks from "aws-cdk-lib/aws-stepfunctions-tasks";
-import * as events from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { ExportStatus, PackagingStateMachineProps } from "./types";
 import { EXPORT_STATUS, FILES } from "./constants";
 import { ReadmeTemplate } from "./templates/readme";
-import { EntryTemplate } from "./templates/entry";
 
 export class PackagingStateMachine extends Construct {
     public readonly stateMachine: stepfunctions.StateMachine;
@@ -132,7 +130,7 @@ export class PackagingStateMachine extends Construct {
         // const entryTemplate = new EntryTemplate(this);
 
         return readmeTemplate.write(this.stringProcessor, this.props.bucket, FILES.README_MD);
-            //.next(entryTemplate.write(this.stringProcessor, this.props.bucket, FILES.ENTRY_MD));
+        //.next(entryTemplate.write(this.stringProcessor, this.props.bucket, FILES.ENTRY_MD));
     }
 
     private createDefinition(): stepfunctions.IChainable {
@@ -328,7 +326,7 @@ export class PackagingStateMachine extends Construct {
         }S3`;
         const resultPath = bodyPath.replace("Body", "put") + "Result";
 
-        const parameters: Record<string, any> = {
+        const parameters: Record<string, string> = {
             Bucket: bucket.bucketName,
             "Key.$": `States.Format('{}/{}', $.packageName, '${filename}')`,
             "Body.$": bodyPath,

--- a/lib/webhook-state-machine.ts
+++ b/lib/webhook-state-machine.ts
@@ -1,8 +1,6 @@
 import * as stepfunctions from "aws-cdk-lib/aws-stepfunctions";
 import * as tasks from "aws-cdk-lib/aws-stepfunctions-tasks";
 import * as logs from "aws-cdk-lib/aws-logs";
-import * as s3 from "aws-cdk-lib/aws-s3";
-import * as events from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 
@@ -97,19 +95,19 @@ export class WebhookStateMachine extends Construct {
     ): stepfunctions.IChainable {
         const startPackagingExecution = new tasks
             .StepFunctionsStartExecution(this, "StartPackagingExecution", {
-            stateMachine: packagingStateMachine,
-            input: stepfunctions.TaskInput.fromObject({
-                entity: stepfunctions.JsonPath.stringAt("$.var.entity"),
-                packageName: stepfunctions.JsonPath.stringAt(
-                    `States.Format('{}/{}', '${this.props.prefix}', $.var.entity)`,
-                ),
-                registry: this.props.bucket.bucketName,
-                baseURL: stepfunctions.JsonPath.stringAt("$.baseURL"),
-                message: stepfunctions.JsonPath.stringAt("$.message"),
-            }),
-            integrationPattern:
-                stepfunctions.IntegrationPattern.REQUEST_RESPONSE,
-        });
+                stateMachine: packagingStateMachine,
+                input: stepfunctions.TaskInput.fromObject({
+                    entity: stepfunctions.JsonPath.stringAt("$.var.entity"),
+                    packageName: stepfunctions.JsonPath.stringAt(
+                        `States.Format('{}/{}', '${this.props.prefix}', $.var.entity)`,
+                    ),
+                    registry: this.props.bucket.bucketName,
+                    baseURL: stepfunctions.JsonPath.stringAt("$.baseURL"),
+                    message: stepfunctions.JsonPath.stringAt("$.message"),
+                }),
+                integrationPattern:
+                    stepfunctions.IntegrationPattern.REQUEST_RESPONSE,
+            });
 
         const errorHandler = new stepfunctions.Pass(this, "HandleError", {
             parameters: {
@@ -144,9 +142,9 @@ export class WebhookStateMachine extends Construct {
                 statusCode: 200,
                 body: JSON.stringify({
                     message: "Package creation started",
-                    status: "success"
-                })
-            }
+                    status: "success",
+                }),
+            },
         });
 
         return buttonMetadataTask
@@ -181,7 +179,7 @@ export class WebhookStateMachine extends Construct {
                     },
                     resultPath: "$.var",
                 })
-                .next(startPackagingExecution),
+                    .next(startPackagingExecution),
             )
             .when(
                 stepfunctions.Condition.or(


### PR DESCRIPTION
## Summary
This PR cleans up various linting issues and improves code quality as preparation for the canvas improvements.

## Changes
- Remove unused imports across multiple files (`benchling-webhook-stack.ts`, `packaging-state-machine.ts`, `webhook-state-machine.ts`)
- Fix indentation and formatting issues throughout codebase  
- Replace `any` type with more specific `Record<string, string>` type
- Add missing trailing commas for consistent formatting

## Related Issues
Addresses #95 - These changes prepare the codebase for implementing the canvas improvements described in the issue.

## Testing
- [x] All linting issues resolved
- [x] Code builds successfully
- [x] No functional changes - only code quality improvements

These changes create a clean foundation for implementing the canvas improvements described in #95.