### PR TITLE
fix(ci): add missing AWS_REGION environment variable to validation step

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -134,6 +134,7 @@ jobs:
           # Run container with minimal config to test startup
           CONTAINER_ID=$(docker run -d \
             -e PORT=8080 \
+            -e AWS_REGION=us-east-1 \
             -e PACKAGER_SQS_URL=https://sqs.us-east-1.amazonaws.com/000000000000/test-queue \
             -e QUILT_WEB_HOST=https://example.quiltdata.com \
             -e ATHENA_USER_DATABASE=test_db \


### PR DESCRIPTION
## Summary

Fixes the CI validation failure where the Docker container startup was failing with:
```
ValueError: Invalid endpoint: https://secretsmanager..amazonaws.com
```

## Root Cause

The validation step in the GitHub Actions workflow was running a Docker container without the `AWS_REGION` environment variable. This caused boto3 to construct an invalid Secrets Manager endpoint URL with a double-dot (`secretsmanager..amazonaws.com` instead of `secretsmanager.us-east-1.amazonaws.com`).

## Changes

- Added `-e AWS_REGION=us-east-1` to the `docker run` command in `.github/workflows/prod.yml`
- This matches the environment variable pattern used in other CI steps

## Testing

This fix ensures the validation step properly tests container startup with correct AWS configuration.

## Related

Fixes: https://github.com/quiltdata/benchling-webhook/actions/runs/19955910692

🤖 Generated with [Claude Code](https://claude.com/claude-code)