### PR TITLE
fix: EventBridge runtime filtering + remove pending canvas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,156 +6,27 @@
 - Always fix IDE diagnostics after edits
 - Docker images ALWAYS pull from centralized ECR: `712023778557.dkr.ecr.us-east-1.amazonaws.com/quiltdata/benchling:latest`
 
-## Testing (Essential Guide)
+## Critical: Use Project npm Scripts
 
-**Full details:** [spec/a08-test-scenarios.md](spec/a08-test-scenarios.md)
+**Version bumps:** Use `npm run version -- minor|patch|major`, NOT `npm version`. The project script syncs `package.json`, `pyproject.toml`, `app-manifest.yaml`, and `uv.lock` in one commit.
 
-### Quick Reference: When to Run What
+**General rule:** Always check `npm run` before assuming a built-in npm command. The project script is always preferred.
 
-```bash
-# PRE-COMMIT (always run before committing)
-npm test                     # ~20s: TS + Python unit tests + lint + typecheck
-
-# BEFORE MERGING PR
-npm run test:integration     # ~2m: Full TypeScript integration tests
-npm run test:local           # ~45s: Local Docker dev build + webhook tests
-
-# AFTER MAKING DOCKER CHANGES (requires local build only)
-npm run test:local:prod      # ~60s: Test production Docker build locally
-
-# AFTER CI BUILDS IMAGE (requires git tag + CI completion)
-npm run test:dev             # ~5m: Deploy to dev + test (auto-deploys if needed)
-npm run test:prod            # ~10s: Health check prod deployment (non-invasive)
-cd docker && make test-ecr   # ~90s: Validate published ECR image
-```
-
-### Critical Dependencies
-
-**Docker Images:** All deployments pull from centralized ECR `712023778557.dkr.ecr.us-east-1.amazonaws.com/quiltdata/benchling:latest`
-
-**CI Build Required For:**
-
-- `npm run test:dev` - Requires Docker image in ECR
-- `npm run test:prod` - Requires Docker image in ECR
-- `make test-ecr` - Requires Docker image in ECR
-
-**CI Build Trigger:**
+## Testing: When to Run What
 
 ```bash
-npm run version:tag:dev      # Creates git tag → triggers CI → builds/pushes Docker image
+npm test                     # PRE-COMMIT (always)
+npm run test:integration     # BEFORE MERGING PR
+npm run test:local           # AFTER DOCKER CHANGES
+npm run test:local:prod      # AFTER DOCKER PROD CHANGES
+npm run test:dev             # AFTER CI BUILDS IMAGE (needs git tag first)
 ```
 
-### Test Categories Summary
+CI build trigger: `npm run version:tag:dev`
 
-| Test | Duration | CI Dep | When |
-|------|----------|--------|------|
-| `npm test` | ~20s | ❌ | Pre-commit (always) |
-| `npm run test:integration` | ~2m | ❌ | Before merging PR |
-| `npm run test:local` | ~45s | ❌ | Docker dev changes |
-| `npm run test:local:prod` | ~60s | ❌ | Docker prod changes |
-| `npm run test:dev` | ~5m | ✅ | After CI builds image |
-| `npm run test:prod` | ~10s | ✅ | Validate prod deployment |
+## Gotchas
 
-**Legend:** CI Dep = Requires CI to have built Docker image
-
-### Common Test Issues
-
-| Error | Solution |
-|-------|----------|
-| `No profile found` | `npm run setup` |
-| `Image not found in ECR` | `npm run version:tag:dev` (triggers CI build) |
-| `ECR authentication failed` | `aws sso login` |
-| `Timeout waiting for health` | Check logs: `docker logs {container}` |
-
-## Key Repository Commands
-
-### Development Workflow
-
-```bash
-npm run setup                # Interactive config wizard (one-time)
-npm test                     # Fast pre-commit tests
-npm run test:local           # Test local Docker build
-```
-
-### Release Workflow (Maintainers)
-
-```bash
-npm run version:tag          # Create git tag → triggers CI → builds Docker image
-npm run deploy:prod          # Deploy to production
-```
-
-### Key Files
-
-- [lib/types/stack-config.ts](lib/types/stack-config.ts) - Minimal CDK stack configuration interface
-- [lib/utils/config-transform.ts](lib/utils/config-transform.ts) - ProfileConfig → StackConfig transformation
-- [lib/benchling-webhook-stack.ts](lib/benchling-webhook-stack.ts) - Main CDK stack
-- [bin/commands/deploy.ts](bin/commands/deploy.ts) - Deployment orchestration
-- [docker/](docker/) - FastAPI webhook processor (Python)
-
-## High-Level Architecture
-
-**Flow:** API Gateway (REST v1) → VPC Link → Network Load Balancer → ECS Fargate (FastAPI) → S3 + SQS
-
-**Configuration:** Profile-based XDG config in `~/.config/benchling-webhook/{profile}/config.json`
-
-**Key Concepts:**
-
-- **Profile** - Named config set (e.g., `default`, `sales`, `dev`)
-- **Stage** - API Gateway deployment target (e.g., `dev`, `prod`)
-- **StackConfig** - Minimal interface for CDK stack (v0.10.0+, decoupled from ProfileConfig)
-
-**Security:**
-
-- Primary: HMAC signature verification in FastAPI
-- Optional: Resource Policy IP filtering (free, when `webhookAllowList` configured)
-
-## Configuration v0.10.0+
-
-**Breaking Change:** Removed unused Iceberg fields (`quilt.athenaUserPolicy`, `quilt.athenaResultsBucketPolicy`, `quilt.athenaResultsBucket`)
-
-**New Architecture:**
-
-- CDK stack uses minimal `StackConfig` interface (only required fields)
-- `config-transform.ts` converts ProfileConfig → StackConfig
-- Eliminated subprocess env var round-trip
-- Deployment flow: deploy.ts passes config via stdin to CDK
-
-## Common Patterns
-
-### Creating a PR
-
-```bash
-npm run test                 # Ensure tests pass
-git commit -m "type(scope): description"
-gh pr create                 # Creates PR with conventional format
-```
-
-### Checking Logs
-
-```bash
-npm run logs -- --profile default
-# Checks both API Gateway and ECS container logs
-```
-
-### Multi-Stack Deployments
-
-```bash
-npm run deploy:prod -- --profile sales --yes
-# Creates: BenchlingWebhookStack-sales
-```
-
-## Troubleshooting
-
-| Issue                  | Solution                                                   |
-| ---------------------- | ---------------------------------------------------------- |
-| Missing profile        | Run `npm run setup`                                        |
-| 403 Forbidden (HMAC)   | Check ECS logs for signature errors                        |
-| 403 Forbidden (IP)     | Add IP to `webhookAllowList` or disable filtering          |
-| Stack name conflict    | Use unique `stackName` per profile in config.json          |
-
-## Documentation
-
-- [CLAUDE.md](CLAUDE.md) - Comprehensive project documentation
-- [CHANGELOG.md](CHANGELOG.md) - Release notes and migration guides
-- [spec/](spec/) - Architecture specs and implementation details
-- [docker/README.md](docker/README.md) - FastAPI application documentation
+- `npm run test:dev`, `test:prod`, `make test-ecr` all require CI to have built the Docker image first
+- Integrated mode (`integratedStack: true`) blocks `deploy` — the Quilt stack handles deployment
+- The prefix (`pkg_prefix`) is a runtime secret — never bake it into CloudFormation/IaC
+- Pass args to npm scripts with `--`: `npm run deploy:prod -- --profile sales --yes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- EventBridge rule now matches only on `source` and `detail-type` — bucket and prefix filtering moved to the Docker runtime, where values are available from Secrets Manager. This unblocks integrated-mode stacks where the IaC layer cannot reference secret-derived values.
+
+### Removed
+
+- `PackagePrefix` CloudFormation parameter (filtering now happens at runtime in the Docker handler)
+
 ## [0.15.0] - 2026-04-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - EventBridge rule now matches only on `source` and `detail-type` — bucket and prefix filtering moved to the Docker runtime, where values are available from Secrets Manager. This unblocks integrated-mode stacks where the IaC layer cannot reference secret-derived values.
+- Canvas footer now shows "Pending update" (honest) instead of "Up to date" (a lie) when no confirmed update timestamp exists
 
 ### Removed
 
 - `PackagePrefix` CloudFormation parameter (filtering now happens at runtime in the Docker handler)
+- Pending canvas state — the intermediate "Updating..." canvas with disabled buttons and stripped links was removed entirely; the canvas now stays unchanged until the EventBridge package event confirms the update, then renders the final state with a real timestamp
 
 ## [0.15.0] - 2026-04-10
 

--- a/bin/commands/deploy.ts
+++ b/bin/commands/deploy.ts
@@ -761,7 +761,6 @@ export async function deploy(
             `BenchlingSecretARN=${benchlingSecret}`,
             `ImageTag=${options.imageTag}`,
             `PackageBucket=${config.packages.bucket}`,
-            `PackagePrefix=${config.packages.prefix || "benchling"}`,
             `QuiltDatabase=${config.quilt.database || ""}`,  // IAM permissions only (same value as AthenaUserDatabase)
             `LogLevel=${config.logging?.level || "INFO"}`,
         ];

--- a/docker/app-manifest.yaml
+++ b/docker/app-manifest.yaml
@@ -2,7 +2,7 @@ manifestVersion: 1
 info:
   name: nightly-quilttest-com
   description: Packaging Benchling Notebooks as Quilt packages
-  version: 0.15.0
+  version: 0.16.0
 features:
   - name: Quilt Connector
     id: quilt_entry

--- a/docker/pyproject.toml
+++ b/docker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "benchling-quilt-integration"
-version = "0.15.0"
+version = "0.16.0"
 description = "Benchling-Quilt Integration Webhook Service"
 license = {text = "Apache-2.0"}
 authors = [

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -850,6 +850,15 @@ def create_app() -> FastAPI:
                 )
                 return JSONResponse({"error": "Forbidden"}, status_code=403)
 
+            expected_prefix = f"{config.pkg_prefix}/"
+            if not package_name.startswith(expected_prefix):
+                logger.info(
+                    "Ignored package event outside prefix",
+                    package_name=package_name,
+                    expected_prefix=expected_prefix,
+                )
+                return JSONResponse({"status": "IGNORED"}, status_code=200)
+
             top_hash = detail.get("topHash")
             if top_hash is not None and not isinstance(top_hash, str):
                 raise ValueError("package event detail.topHash must be a string when present")

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -697,20 +697,8 @@ def create_app() -> FastAPI:
                     event_type=payload.event_type,
                     canvas_id=payload.canvas_id,
                 )
-                canvas_manager = CanvasManager(benchling, config, payload)
-
                 logger.debug("Starting background export workflow from /event", entry_id=payload.entry_id)
                 entry_packager.execute_workflow_async(payload)
-
-                def async_pending_canvas_from_event():
-                    try:
-                        canvas_manager.update_canvas_pending()
-                    except Exception as e:
-                        logger.error(
-                            "Failed to set pending canvas from /event", canvas_id=payload.canvas_id, error=str(e)
-                        )
-
-                threading.Thread(target=async_pending_canvas_from_event, daemon=True).start()
 
                 logger.info("Canvas update initiated from /event endpoint", canvas_id=payload.canvas_id)
                 return JSONResponse(
@@ -1013,21 +1001,8 @@ def create_app() -> FastAPI:
             logger.debug("Starting background export workflow", entry_id=payload.entry_id)
             execution_arn = entry_packager.execute_workflow_async(payload)
 
-            canvas_manager = CanvasManager(benchling, config, payload)
-
-            # Push pending canvas via SDK in background thread.
-            # Benchling ignores blocks in the webhook response body —
-            # canvas content must be set via the update_canvas API.
-            def async_pending_canvas():
-                try:
-                    canvas_manager.update_canvas_pending()
-                except Exception as e:
-                    logger.error("Failed to set pending canvas", canvas_id=payload.canvas_id, error=str(e))
-
-            threading.Thread(target=async_pending_canvas, daemon=True).start()
-
             logger.info(
-                "Canvas update initiated (pending state)",
+                "Canvas update initiated",
                 canvas_id=payload.canvas_id,
                 entry_id=payload.entry_id,
                 event_type=payload.event_type,

--- a/docker/src/canvas.py
+++ b/docker/src/canvas.py
@@ -183,17 +183,13 @@ class CanvasManager:
         """
         return self.package.upload_url
 
-    def _make_markdown_content(self, pending: bool = False) -> str:
+    def _make_markdown_content(self) -> str:
         """Generate markdown content for the Canvas.
 
         Composes the full canvas content in the following order:
         1. Primary package information
-        2. Notice and status
-        3. Linked packages (if any)
-        4. Error notifications (if any)
-
-        Args:
-            pending: If True, render links as plain text (package not yet created)
+        2. Linked packages (if any)
+        3. Error notifications (if any)
 
         Returns:
             Formatted markdown string with package links
@@ -204,7 +200,6 @@ class CanvasManager:
             display_id=self.entry.display_id,
             catalog_url=self.catalog_url,
             sync_url=self.sync_uri(),
-            pending=pending,
         )
 
         # Linked packages
@@ -220,7 +215,7 @@ class CanvasManager:
             # Store linked packages as instance variable
             self._linked_packages = linked_packages
 
-            content += fmt.format_linked_packages(linked_packages, pending=pending)
+            content += fmt.format_linked_packages(linked_packages)
 
         except Exception as e:
             error_msg = f"Failed to search for linked packages: {str(e)}"
@@ -240,23 +235,22 @@ class CanvasManager:
 
         return content
 
-    def _make_blocks(self, pending: bool = False, updated_at: str | None = None) -> list:
+    def _make_blocks(self, updated_at: str | None = None) -> list:
         """Create UI blocks for the Canvas.
 
         Args:
-            pending: If True, disable buttons and links, show "Updating..." footer
-            updated_at: ISO timestamp of last package update (shown when not pending)
+            updated_at: ISO timestamp of last package update
         """
-        markdown_content = self._make_markdown_content(pending=pending)
+        markdown_content = self._make_markdown_content()
         markdown_block = blocks.create_markdown_block(markdown_content, "md1")
 
         result = [
-            *blocks.create_main_navigation_buttons(self.entry_id, enabled=not pending),
+            *blocks.create_main_navigation_buttons(self.entry_id),
             markdown_block,
         ]
 
-        # Add linked package browse buttons if any exist (disabled when pending)
-        if self._linked_packages and not pending:
+        # Add linked package browse buttons if any exist
+        if self._linked_packages:
             result.extend(blocks.create_linked_package_browse_buttons(self.entry_id, self._linked_packages))
 
         # Add footer as markdown block
@@ -264,21 +258,11 @@ class CanvasManager:
             version=__version__,
             quilt_host=self.config.quilt_catalog,
             bucket=self.config.s3_bucket_name,
-            pending=pending,
             updated_at=updated_at,
         )
         result.append(blocks.create_markdown_block(footer_markdown, "md-footer"))
 
         return result
-
-    def update_canvas_pending(self) -> dict[str, Any]:
-        """Push pending canvas with full content but disabled links/buttons.
-
-        Shows the same information as the final canvas so the user can see
-        where the package will be. Only the status line and button state differ.
-        """
-        blocks = self._make_blocks(pending=True)
-        return self.update_canvas_with_blocks(blocks)
 
     def update_canvas(self, updated_at: str | None = None) -> dict[str, Any]:
         """Update existing Canvas using Benchling SDK.

--- a/docker/src/canvas_blocks.py
+++ b/docker/src/canvas_blocks.py
@@ -90,12 +90,11 @@ def create_section(section_id: str, buttons: List[ButtonUiBlock]) -> SectionUiBl
     )
 
 
-def create_main_navigation_buttons(entry_id: str, enabled: bool = True) -> List:
+def create_main_navigation_buttons(entry_id: str) -> List:
     """Create main view navigation buttons (Browse Package, Update Package).
 
     Args:
         entry_id: Entry identifier for button IDs
-        enabled: Whether buttons are interactive (False during pending state)
 
     Returns:
         List containing section with navigation buttons
@@ -104,12 +103,10 @@ def create_main_navigation_buttons(entry_id: str, enabled: bool = True) -> List:
         create_button(
             button_id=f"browse-files-{entry_id}-p0-s15",
             text="Browse Package",
-            enabled=enabled,
         ),
         create_button(
             button_id=f"update-package-{entry_id}",
             text="Update Package",
-            enabled=enabled,
         ),
     ]
 

--- a/docker/src/canvas_formatting.py
+++ b/docker/src/canvas_formatting.py
@@ -39,9 +39,7 @@ def linkify_urls(text: str) -> str:
     return URL_PATTERN.sub(replace_url, text)
 
 
-def format_package_header(
-    package_name: str, display_id: str, catalog_url: str, sync_url: str, pending: bool = False
-) -> str:
+def format_package_header(package_name: str, display_id: str, catalog_url: str, sync_url: str) -> str:
     """Format primary package header with action links.
 
     Args:
@@ -49,28 +47,21 @@ def format_package_header(
         display_id: Entry display ID
         catalog_url: URL to catalog view
         sync_url: URL for sync action
-        pending: If True, render as plain text (no links)
 
     Returns:
         Formatted markdown string
     """
-    if pending:
-        return f"""## {display_id}
-
-* Package: {package_name}
-"""
     return f"""## {display_id}
 
 * Package: [{package_name}]({catalog_url}) [[🔄 sync]]({sync_url})
 """
 
 
-def format_linked_packages(packages: List[Package], pending: bool = False) -> str:
+def format_linked_packages(packages: List[Package]) -> str:
     """Format linked packages section.
 
     Args:
         packages: List of Package instances to display
-        pending: If True, render as plain text (no links)
 
     Returns:
         Formatted markdown string, or empty string if no packages
@@ -80,10 +71,7 @@ def format_linked_packages(packages: List[Package], pending: bool = False) -> st
 
     content = "\n### Linked Packages\n\n"
     for pkg in packages:
-        if pending:
-            content += f"* {pkg.package_name}\n"
-        else:
-            content += f"* [{pkg.package_name}]({pkg.catalog_url}) [[🔄 sync]]({pkg.make_sync_url()})\n"
+        content += f"* [{pkg.package_name}]({pkg.catalog_url}) [[🔄 sync]]({pkg.make_sync_url()})\n"
     return content
 
 
@@ -277,27 +265,22 @@ def dict_to_markdown_list(data: Dict[str, Any], indent_level: int = 0) -> str:
     return md
 
 
-def format_canvas_footer(
-    version: str, quilt_host: str, bucket: str, pending: bool = False, updated_at: str | None = None
-) -> str:
+def format_canvas_footer(version: str, quilt_host: str, bucket: str, updated_at: str | None = None) -> str:
     """Format canvas footer with version and deployment information.
 
     Args:
         version: Application version
         quilt_host: Quilt catalog host
         bucket: S3 bucket name
-        pending: If True, show "Updating..." status
-        updated_at: ISO timestamp of last package update (shown when not pending)
+        updated_at: ISO timestamp of last package update
 
     Returns:
         Formatted markdown string with footer information
     """
-    if pending:
-        status = "⏳ *Updating...*"
-    elif updated_at:
+    if updated_at:
         status = f"✅ *Updated at {updated_at}*"
     else:
-        status = "✅ *Up to date*"
+        status = "⏳ *Pending update*"
     return f"""
 
 ---

--- a/docker/tests/test_app.py
+++ b/docker/tests/test_app.py
@@ -259,6 +259,19 @@ class TestFastAPIApp:
         assert response.status_code == status_code
         assert error_fragment in response.json()["error"]
 
+    def test_package_event_endpoint_ignores_outside_prefix(self, client):
+        """Test package-event endpoint ignores events whose handle doesn't match pkg_prefix."""
+        event_payload = {
+            "detail": {
+                "bucket": "test-bucket",
+                "handle": "other-prefix/EXP0001",
+            }
+        }
+        response = client.post("/package-event", json=event_payload)
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "IGNORED"
+
     def test_package_event_endpoint_skips_stale_revisions(self, client):
         """Test package-event endpoint skips stale package revisions."""
         event_payload = {

--- a/docker/tests/test_app.py
+++ b/docker/tests/test_app.py
@@ -131,8 +131,8 @@ class TestFastAPIApp:
         assert "error" in data
         assert "not found" in data["error"].lower()
 
-    def test_canvas_endpoint_returns_pending_canvas(self, client, mock_entry_packager):
-        """Test /canvas endpoint returns 202 and updates canvas via SDK in background."""
+    def test_canvas_endpoint_starts_workflow(self, client, mock_entry_packager):
+        """Test /canvas endpoint returns 202 and starts workflow."""
         mock_entry_packager.execute_workflow_async.return_value = "etr_123456"
 
         payload = {
@@ -142,25 +142,14 @@ class TestFastAPIApp:
             "context": {"canvasId": "canvas_123"},
         }
 
-        with patch("src.app.CanvasManager") as mock_canvas_manager:
-            mock_manager_instance = Mock()
-            mock_canvas_manager.return_value = mock_manager_instance
-            mock_manager_instance.update_canvas_pending.return_value = {"success": True}
+        response = client.post("/canvas", json=payload)
 
-            response = client.post("/canvas", json=payload)
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "ACCEPTED"
 
-            assert response.status_code == 202
-            data = response.json()
-            assert data["status"] == "ACCEPTED"
-
-            # Give background thread time to run
-            import time
-
-            time.sleep(0.1)
-
-            mock_manager_instance.update_canvas_pending.assert_called_once()
-            workflow_payload = mock_entry_packager.execute_workflow_async.call_args.args[0]
-            assert workflow_payload.canvas_id == "canvas_123"
+        workflow_payload = mock_entry_packager.execute_workflow_async.call_args.args[0]
+        assert workflow_payload.canvas_id == "canvas_123"
 
     def test_package_event_endpoint_refreshes_canvas_in_background(self, client):
         """Test package-event endpoint returns immediately and refreshes canvas asynchronously."""

--- a/docker/tests/test_canvas_blocks_footer.py
+++ b/docker/tests/test_canvas_blocks_footer.py
@@ -23,16 +23,9 @@ class TestCanvasFooterBlocks:
         footer = format_canvas_footer(version="0.8.4", quilt_host="test.com", bucket="test-bucket")
 
         assert isinstance(footer, str)
-        assert "Up to date" in footer
+        assert "Pending update" in footer
         assert "test-bucket@test.com" in footer
         assert "Rev 0.8.4" in footer
-
-    def test_format_canvas_footer_pending(self):
-        """Verify pending state shows 'Updating...'."""
-        footer = format_canvas_footer(version="0.8.4", quilt_host="test.com", bucket="test-bucket", pending=True)
-
-        assert "Updating..." in footer
-        assert "Up to date" not in footer
 
     def test_format_canvas_footer_with_timestamp(self):
         """Verify updated_at timestamp is shown."""
@@ -80,7 +73,7 @@ class TestCanvasFooterBlocks:
 
         # Verify footer content
         footer_content = last_block.value
-        assert "Up to date" in footer_content
+        assert "Pending update" in footer_content
         assert mock_config.s3_bucket_name in footer_content
         assert mock_config.quilt_catalog in footer_content
 
@@ -118,7 +111,7 @@ class TestCanvasFooterBlocks:
         footer_block_dict = blocks_dict[-1]
         assert footer_block_dict["type"] == "MARKDOWN"
         assert footer_block_dict["id"] == "md-footer"
-        assert "Up to date" in footer_block_dict["value"]
+        assert "Pending update" in footer_block_dict["value"]
 
     def test_blocks_to_dict_rejects_invalid_blocks(self):
         """Verify blocks_to_dict raises TypeError for invalid block types."""

--- a/docker/tests/test_flexible_routes.py
+++ b/docker/tests/test_flexible_routes.py
@@ -194,21 +194,11 @@ class TestFlexibleRoutes:
             "context": {"canvasId": "canvas_123"},
         }
 
-        with patch("src.app.CanvasManager") as mock_canvas_manager:
-            mock_manager_instance = Mock()
-            mock_canvas_manager.return_value = mock_manager_instance
-            mock_manager_instance.update_canvas_pending.return_value = {"success": True}
+        response = client.post(f"/{stage}/canvas", json=payload)
 
-            response = client.post(f"/{stage}/canvas", json=payload)
-
-            assert response.status_code == 202
-            data = response.json()
-            assert data["status"] == "ACCEPTED"
-
-            import time
-
-            time.sleep(0.1)
-            mock_manager_instance.update_canvas_pending.assert_called_once()
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "ACCEPTED"
 
     def test_canvas_webhook_direct_path(self, client, mock_entry_packager):
         """Test /canvas webhook without stage prefix returns 202."""
@@ -219,16 +209,11 @@ class TestFlexibleRoutes:
             "context": {"canvasId": "canvas_123"},
         }
 
-        with patch("src.app.CanvasManager") as mock_canvas_manager:
-            mock_manager_instance = Mock()
-            mock_canvas_manager.return_value = mock_manager_instance
-            mock_manager_instance.update_canvas_pending.return_value = {"success": True}
+        response = client.post("/canvas", json=payload)
 
-            response = client.post("/canvas", json=payload)
-
-            assert response.status_code == 202
-            data = response.json()
-            assert data["status"] == "ACCEPTED"
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "ACCEPTED"
 
     # ============================================================================
     # Verify both path styles produce identical responses

--- a/docker/uv.lock
+++ b/docker/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "benchling-quilt-integration"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "benchling-sdk" },

--- a/lib/benchling-webhook-stack.ts
+++ b/lib/benchling-webhook-stack.ts
@@ -129,12 +129,6 @@ export class BenchlingWebhookStack extends cdk.Stack {
             description: "S3 bucket name for Quilt packages (resolved from Quilt stack outputs at runtime)",
             default: "",  // StackConfig doesn't include package bucket - only passed via env vars
         });
-        const packagePrefixParam = new cdk.CfnParameter(this, "PackagePrefix", {
-            type: "String",
-            description: "Package handle prefix to match Quilt package revision events",
-            default: "benchling",
-        });
-
         const quiltDatabaseParam = new cdk.CfnParameter(this, "QuiltDatabase", {
             type: "String",
             description: "Glue database name for Quilt packages (resolved from Quilt stack outputs at runtime)",
@@ -151,7 +145,6 @@ export class BenchlingWebhookStack extends cdk.Stack {
         const logLevelValue = logLevelParam.valueAsString;
         const imageTagValue = imageTagParam.valueAsString;
         const packageBucketValue = packageBucketParam.valueAsString;
-        const packagePrefixValue = packagePrefixParam.valueAsString;
         const quiltDatabaseValue = quiltDatabaseParam.valueAsString;
 
         const createAthenaWorkgroupCondition = new cdk.CfnCondition(this, "CreateAthenaWorkgroup", {
@@ -340,10 +333,6 @@ export class BenchlingWebhookStack extends cdk.Stack {
             eventPattern: {
                 source: ["com.quiltdata"],
                 detailType: ["package-revision"],
-                detail: {
-                    bucket: [packageBucketValue],
-                    handle: [{ prefix: `${packagePrefixValue}/` }],
-                },
             },
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quiltdata/benchling-webhook",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@quiltdata/benchling-webhook",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.953.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quiltdata/benchling-webhook",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "AWS CDK deployment for Benchling webhook processing using Fargate - Deploy directly with npx",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/spec/2026-04-11-iac-integrated/01-iac-breakage.md
+++ b/spec/2026-04-11-iac-integrated/01-iac-breakage.md
@@ -1,0 +1,125 @@
+# IAC Breakage Analysis: EventBridge Rule for Integrated Stack
+
+## Context
+
+Commits `c90d15a` (canvas refresh, PR #375) and `1f728f2` (IaC for integrated
+mode, PR #377) introduced two features that are **broken** for the integrated
+stack:
+
+1. **Prefix filter in EventBridge rule** — uses a deploy-time parameter for a
+   value that is a runtime secret
+2. **Missing EventBridge rule** — only exists in the standalone CDK stack, not
+   in the Quilt stack IaC needed for integrated mode
+
+---
+
+## Recommendation
+
+### 1. Move ALL filtering from EventBridge rule to Docker
+
+Both the prefix and bucket are runtime values from Secrets Manager — the
+CDK/IaC layer cannot know them. The EventBridge rule should match only on
+`source` and `detail-type`. All filtering happens in Docker, where the config
+is available.
+
+**EventBridge rule (both standalone and integrated):**
+
+```json
+{
+    "source": ["com.quiltdata"],
+    "detail-type": ["package-revision"]
+}
+```
+
+No bucket filter. No prefix filter. Zero dependency on IaC knowing anything
+from the secret.
+
+**Docker (`app.py`, in `_handle_package_event_impl`):**
+
+The existing bucket check at line 844 stays. Add prefix filtering after it:
+
+```python
+expected_prefix = f"{config.pkg_prefix}/"
+if not package_name.startswith(expected_prefix):
+    logger.info("Ignored package event outside prefix",
+                package_name=package_name, expected_prefix=expected_prefix)
+    return JSONResponse({"status": "IGNORED"}, status_code=200)
+```
+
+**Cleanup:** Remove `PackagePrefix` CfnParameter and `PackageBucket` from the
+EventBridge rule pattern in `benchling-webhook-stack.ts`, and the
+corresponding `PackagePrefix` override in `deploy.ts:764`.
+
+### 2. Add EventBridge rule to Quilt stack IaC for integrated mode
+
+The Quilt stack IaC must create the EventBridge rule, IAM role, and API Gateway
+resource policy when `BenchlingIntegration` is enabled. These resources
+currently only exist in the standalone CDK stack.
+
+The rule goes on the **default bus** (where `pkgevents` Lambda publishes) and
+requires no secret-derived values — just `source` and `detail-type`:
+
+```python
+# Quilt stack IaC (troposphere), gated on BenchlingIntegration
+events.Rule(
+    "BenchlingPackageRevisionRule",
+    EventPattern={
+        "source": ["com.quiltdata"],
+        "detail-type": ["package-revision"],
+    },
+    Targets=[...],  # API Gateway POST /package-event
+)
+```
+
+This can be created before the secret is populated, with no ordering
+dependency.
+
+---
+
+## Changes Required
+
+| Where                            | What                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------- |
+| `lib/benchling-webhook-stack.ts` | Remove `handle` prefix and `bucket` from rule pattern                            |
+| `lib/benchling-webhook-stack.ts` | Remove `PackagePrefix` CfnParameter                                             |
+| `bin/commands/deploy.ts`         | Remove `PackagePrefix` from parameter overrides                                  |
+| `docker/src/app.py`              | Add runtime prefix filtering in `/package-event` handler                         |
+| Quilt stack IaC (external)       | Add EventBridge rule + IAM role + API GW policy, gated on `BenchlingIntegration` |
+
+---
+
+## Appendix: EventBridge Bus and Scoping Investigation
+
+During analysis we investigated whether filtering in the EventBridge rule is
+necessary for correctness.
+
+### What we found
+
+- The Quilt stack creates a **custom EventBridge bus** per stack
+  (`quilt-${StackName}`) in `deployment/t4/template/events.py`.
+- However, the `pkgevents` Lambda publishes `package-revision` events to the
+  **default bus** — it calls `put_events()` without specifying `EventBusName`.
+  This contrasts with `S3SNSToEventBridge`, which explicitly targets the custom
+  bus via a `BUS_ARN` env var.
+- The event detail contains **no stack identifier** — just `bucket`, `handle`,
+  `topHash`, `type`, and `version`.
+
+Filed as quiltdata/enterprise#1028: add source stack info to event detail and
+publish to the custom bus.
+
+### Is the bucket filter in the rule required?
+
+**No.** The Docker handler validates the bucket (`app.py:844`) and rejects
+mismatches. Without the bucket filter, the only cost is unnecessary API Gateway
+invocations from other stacks in the same account — rejected at the application
+layer. Duplicate events from a same-bucket scenario can be debounced.
+
+### Why not keep the bucket filter as an optimization?
+
+The bucket name is configured in the benchling-webhook secret during the setup
+wizard. The Quilt IaC does not necessarily have it as a parameter. Requiring
+the bucket in the rule would create a dependency between IaC and the secret,
+defeating the goal of letting the rule be created independently, before the
+secret is populated.
+
+The Docker layer is the correctness gate for both bucket and prefix.

--- a/spec/2026-04-11-iac-integrated/02-table-wildcard.md
+++ b/spec/2026-04-11-iac-integrated/02-table-wildcard.md
@@ -1,0 +1,44 @@
+# TableWildcard Grant Failure
+
+## Why we thought we needed it
+
+When Lake Formation enforcement is active (IAMAllowedPrincipals removed from
+both CreateDatabaseDefaultPermissions and CreateTableDefaultPermissions),
+IAM-only roles lose access to Glue tables even with correct IAM policies.
+
+Database-level LF grants restore access to the database itself, but not to
+tables inside it. We added TableWildcard grants to cover:
+
+- **Dynamically-created tables** (per-bucket views in UserAthenaDatabase)
+  that don't exist at deploy time and can't have individual CFN grants.
+- **Iceberg tables** (package_revision, package_entry, etc.) which are
+  CFN-managed but weren't listed in the per-table grants.
+
+## Why it didn't work
+
+AWS Lake Formation rejects TableWildcard grants for the IAM_ALLOWED_PRINCIPALS
+principal. This is an AWS-side restriction: IAM_ALLOWED_PRINCIPALS is a special
+principal that opts resources out of LF control, and AWS does not allow it to be
+combined with TableWildcard. The grant works for normal principals/roles, but
+not for this opt-out mechanism.
+
+## What to do instead
+
+Both fixes are needed — once LF enforcement is active, every Glue path hits LF.
+
+1. **CFN-managed tables** (Iceberg, NamedPackages, AuditTrail): add explicit
+   per-table IAM_ALLOWED_PRINCIPALS grants for each.
+
+2. **Dynamically-created tables** (UserAthenaDatabase views): replace the
+   IAM_ALLOWED_PRINCIPALS TableWildcard grants with per-role TableWildcard
+   grants. TableWildcard itself is fine — the restriction is only on
+   combining it with IAM_ALLOWED_PRINCIPALS.
+
+   Roles that need UserAthenaDatabase TableWildcard grants:
+   - **AmazonECSTaskExecutionRole** (Registry) — creates/updates/deletes tables
+   - **BenchlingTaskRole** — queries tables via Athena
+   - **IcebergLambdaRole** — queries tables via Athena
+   - **TabulatorOpenQueryRole** — queries tables via Athena
+   - **T4BucketReadRole** — queries tables (user-facing)
+   - **T4BucketWriteRole** — queries tables (user-facing)
+   - **ManagedUserRole** — queries tables (user-facing)

--- a/spec/2026-04-11-iac-integrated/02-table-wildcard.md
+++ b/spec/2026-04-11-iac-integrated/02-table-wildcard.md
@@ -11,38 +11,45 @@ tables inside it. We added TableWildcard grants to cover:
 
 - **Dynamically-created tables** (per-bucket views in UserAthenaDatabase)
   that don't exist at deploy time and can't have individual CFN grants.
-- **Iceberg tables** (package_revision, package_entry, etc.) which are
-  CFN-managed but weren't listed in the per-table grants.
+- **Iceberg tables** (package_revision, package_entry, etc.) which are also
+  created at runtime, not CFN-managed.
 
-## Why it didn't work
+## Attempt 1: IAM_ALLOWED_PRINCIPALS + TableWildcard
 
-AWS Lake Formation rejects TableWildcard grants for the IAM_ALLOWED_PRINCIPALS
-principal. This is an AWS-side restriction: IAM_ALLOWED_PRINCIPALS is a special
-principal that opts resources out of LF control, and AWS does not allow it to be
-combined with TableWildcard. The grant works for normal principals/roles, but
-not for this opt-out mechanism.
+AWS Lake Formation rejects this combination. IAM_ALLOWED_PRINCIPALS is a
+special principal that opts resources out of LF control, and AWS does not
+allow it with TableWildcard.
 
-## What to do instead
+Error: "Grant on table wildcard is not allowed"
 
-Both fixes are needed — once LF enforcement is active, every Glue path hits LF.
+## Attempt 2: Per-role TableWildcard grants
 
-1. **CFN-managed tables** (NamedPackages, AuditTrail): already have explicit
-   per-table IAM_ALLOWED_PRINCIPALS grants in _TABLE_GRANTS. No change needed.
+Replaced IAM_ALLOWED_PRINCIPALS with per-role grants (GetAtt role ARN).
+TableWildcard works for normal roles, but the CFN execution role is not a
+Lake Formation admin, so it cannot grant LF permissions to other roles.
 
-2. **Dynamically-created tables**: replace the IAM_ALLOWED_PRINCIPALS
-   TableWildcard grants with per-role TableWildcard grants. TableWildcard
-   itself is fine — the restriction is only on combining it with
-   IAM_ALLOWED_PRINCIPALS.
+Error: "Resource does not exist or requester is not authorized to access
+requested permissions" (AccessDeniedException, 9 failures — one per grant)
 
-   **UserAthenaDatabase** (per-bucket views, created by Registry at runtime):
-   - **AmazonECSTaskExecutionRole** — creates/updates/deletes tables
-   - **BenchlingTaskRole** — queries tables via Athena
-   - **IcebergLambdaRole** — queries tables via Athena
-   - **TabulatorOpenQueryRole** — queries tables via Athena
-   - **T4BucketReadRole** — queries tables (user-facing)
-   - **T4BucketWriteRole** — queries tables (user-facing)
-   - **ManagedUserRole** — queries tables (user-facing)
+## What actually works
 
-   **IcebergDatabase** (tables created by Registry at runtime):
-   - **AmazonECSTaskExecutionRole** — creates/manages tables
-   - **IcebergLambdaRole** — reads/updates tables
+- Database-level IAM_ALLOWED_PRINCIPALS grants — yes
+- Per-table IAM_ALLOWED_PRINCIPALS grants (known CFN tables) — yes
+- TableWildcard with IAM_ALLOWED_PRINCIPALS — no
+- TableWildcard with real roles (without LF admin) — no
+
+## Remaining options for dynamic tables
+
+1. **Restore CreateTableDefaultPermissions** at the account level via
+   AWS::LakeFormation::DataLakeSettings to include IAM_ALLOWED_PRINCIPALS.
+   New tables would automatically get IAM fallthrough. Risk: conflicts with
+   whoever removed the defaults, and requires the CFN role to be LF admin.
+
+2. **Grant IAM_ALLOWED_PRINCIPALS per-table at creation time** in the
+   application code (Registry service). Every time the registry creates a
+   Glue table, it also calls lakeformation:PutDataLakeSettings or
+   lakeformation:GrantPermissions for that table.
+
+3. **Make the CFN execution role a Lake Formation admin** so it can issue
+   per-role grants. This is an infrastructure/Terraform change outside the
+   stack template.

--- a/spec/2026-04-11-iac-integrated/02-table-wildcard.md
+++ b/spec/2026-04-11-iac-integrated/02-table-wildcard.md
@@ -26,19 +26,23 @@ not for this opt-out mechanism.
 
 Both fixes are needed — once LF enforcement is active, every Glue path hits LF.
 
-1. **CFN-managed tables** (Iceberg, NamedPackages, AuditTrail): add explicit
-   per-table IAM_ALLOWED_PRINCIPALS grants for each.
+1. **CFN-managed tables** (NamedPackages, AuditTrail): already have explicit
+   per-table IAM_ALLOWED_PRINCIPALS grants in _TABLE_GRANTS. No change needed.
 
-2. **Dynamically-created tables** (UserAthenaDatabase views): replace the
-   IAM_ALLOWED_PRINCIPALS TableWildcard grants with per-role TableWildcard
-   grants. TableWildcard itself is fine — the restriction is only on
-   combining it with IAM_ALLOWED_PRINCIPALS.
+2. **Dynamically-created tables**: replace the IAM_ALLOWED_PRINCIPALS
+   TableWildcard grants with per-role TableWildcard grants. TableWildcard
+   itself is fine — the restriction is only on combining it with
+   IAM_ALLOWED_PRINCIPALS.
 
-   Roles that need UserAthenaDatabase TableWildcard grants:
-   - **AmazonECSTaskExecutionRole** (Registry) — creates/updates/deletes tables
+   **UserAthenaDatabase** (per-bucket views, created by Registry at runtime):
+   - **AmazonECSTaskExecutionRole** — creates/updates/deletes tables
    - **BenchlingTaskRole** — queries tables via Athena
    - **IcebergLambdaRole** — queries tables via Athena
    - **TabulatorOpenQueryRole** — queries tables via Athena
    - **T4BucketReadRole** — queries tables (user-facing)
    - **T4BucketWriteRole** — queries tables (user-facing)
    - **ManagedUserRole** — queries tables (user-facing)
+
+   **IcebergDatabase** (tables created by Registry at runtime):
+   - **AmazonECSTaskExecutionRole** — creates/manages tables
+   - **IcebergLambdaRole** — reads/updates tables

--- a/spec/2026-04-11-iac-integrated/03-wildcard-failure.md
+++ b/spec/2026-04-11-iac-integrated/03-wildcard-failure.md
@@ -1,0 +1,50 @@
+# Why Per-Role TableWildcard Grants Also Failed
+
+## Context
+
+After discovering that IAM_ALLOWED_PRINCIPALS cannot be combined with
+TableWildcard (see 02-table-wildcard.md), we tried granting TableWildcard
+to each service role individually instead. This also failed.
+
+## What we tried
+
+Replaced the single IAM_ALLOWED_PRINCIPALS TableWildcard grant per database
+with individual TableWildcard grants targeting each role's ARN. Nine grants
+total: seven roles on UserAthenaDatabase, two on IcebergDatabase.
+
+## What happened
+
+All nine grants failed with AccessDeniedException:
+
+"Resource does not exist or requester is not authorized to access
+requested permissions."
+
+## Why
+
+To grant Lake Formation permissions to a role, the caller must itself be
+a Lake Formation administrator. The CloudFormation execution role is not
+a LF admin. It can grant IAM_ALLOWED_PRINCIPALS because that is a special
+built-in mechanism that does not require LF admin status. But granting
+permissions to real IAM roles does require LF admin status.
+
+## What works and what doesn't
+
+| Grant type | Principal | Result |
+|---|---|---|
+| Database-level | IAM_ALLOWED_PRINCIPALS | Works |
+| Per-table (known CFN tables) | IAM_ALLOWED_PRINCIPALS | Works |
+| TableWildcard | IAM_ALLOWED_PRINCIPALS | Rejected by AWS |
+| TableWildcard | Real IAM role ARN | AccessDenied (not LF admin) |
+
+## Remaining options
+
+1. **Make the CFN execution role a Lake Formation admin.** Infrastructure
+   change in Terraform, outside the stack template. Would unblock per-role
+   grants.
+
+2. **Restore CreateTableDefaultPermissions** at the account level to include
+   IAM_ALLOWED_PRINCIPALS. New tables would automatically get IAM
+   fallthrough. Risk: may conflict with whoever removed the defaults.
+
+3. **Grant IAM_ALLOWED_PRINCIPALS per-table at creation time** in the
+   Registry application code, every time it creates a Glue table.

--- a/spec/2026-04-11-iac-integrated/04-lf-admin-list.md
+++ b/spec/2026-04-11-iac-integrated/04-lf-admin-list.md
@@ -1,0 +1,59 @@
+# The Lake Formation Admin List Is the Real Blocker
+
+## Why
+
+Lake Formation maintains its own admin list, separate from IAM. Even a role
+with AdministratorAccess cannot grant LF permissions, modify LF settings, or
+change table defaults unless it is on that list. Every approach we've tried
+— TableWildcard with IAM_ALLOWED_PRINCIPALS, per-role grants, restoring
+table defaults — fails because no role in our infrastructure is an LF admin.
+
+Someone (likely the sus-test stack) enabled LF enforcement and removed
+IAM_ALLOWED_PRINCIPALS from the account defaults. That's valid. But it left
+us with no way to manage LF grants from CloudFormation or application code.
+
+## Options for getting onto the LF admin list
+
+### A. Add the GitHub-Deployment role as LF admin
+
+The OIDC role that runs Terraform already has AdministratorAccess. Adding it
+to the LF admin list would let the CFN stack issue per-role TableWildcard
+grants.
+
+**Pro:** Minimal blast radius — one role, already has full IAM power.
+**Con:** Requires a one-time manual console action or a bootstrap step
+outside Terraform (since Terraform itself can't modify LF settings without
+already being an admin). Chicken-and-egg.
+
+### B. Add the CFN execution role as LF admin
+
+If CloudFormation uses a separate execution role (not the deployment role),
+that role would need to be on the list instead.
+
+**Pro:** Scoped to CFN operations only.
+**Con:** Same chicken-and-egg problem. Also need to confirm which role CFN
+actually uses — it may just be the deployment role.
+
+### C. Add the Registry ECS task role as LF admin
+
+The Registry already creates dynamic Glue tables at runtime. If it were an
+LF admin, it could grant IAM_ALLOWED_PRINCIPALS on each table at creation
+time.
+
+**Pro:** Grants happen at the right moment — when tables are created.
+**Con:** Gives a long-running application role LF admin powers, which is a
+broader privilege than it needs for its day job. Also requires application
+code changes in the Registry.
+
+## The chicken-and-egg problem
+
+To add a role to the LF admin list, you must already be an LF admin (or the
+account root). Since no automation role is currently an LF admin, the first
+addition must be done manually via the AWS console or by the root user.
+After that, Terraform or CFN can manage the list going forward.
+
+## Recommendation
+
+Option A is the simplest path. One manual console action to bootstrap, then
+Terraform manages it from there. The deployment role already has full IAM
+power — adding LF admin doesn't meaningfully expand its blast radius.

--- a/spec/2026-04-11-iac-integrated/05-lf-admin-settings.md
+++ b/spec/2026-04-11-iac-integrated/05-lf-admin-settings.md
@@ -1,0 +1,40 @@
+# Lake Formation Admin Settings — Resolution
+
+## Starting state
+
+Caller: ernest-staging (IAM user, account 712023778557, us-east-2)
+
+LF admin list: ernest-staging, sus-test-provisioning, sus-test-managed-access,
+sergey, kevin-staging. GitHub-Deployment was NOT on the list.
+
+CreateDatabaseDefaultPermissions: empty (LF enforced by sus-test)
+CreateTableDefaultPermissions: empty (LF enforced by sus-test)
+
+## Why ernest-staging couldn't call PutDataLakeSettings
+
+Despite having AdministratorAccess AND being an LF admin, the `quilt-admins`
+IAM group has the AWS managed policy `AWSLakeFormationDataAdmin` attached.
+That policy contains an explicit deny on `lakeformation:PutDataLakeSettings`.
+Explicit deny always wins.
+
+## How we unblocked it
+
+1. Temporarily removed ernest-staging from quilt-admins group
+2. Called PutDataLakeSettings to add GitHub-Deployment to LF admin list
+   (first attempt had wrong ARN — the role has path `/github/`, so the
+   correct ARN is `arn:aws:iam::712023778557:role/github/GitHub-Deployment`)
+3. Restored ernest-staging to quilt-admins group
+
+## Current LF admin list
+
+- ernest-staging
+- sus-test-provisioning
+- sus-test-managed-access
+- sergey
+- kevin-staging
+- **GitHub-Deployment** (newly added)
+
+## Result
+
+Re-ran the CloudFormation deployment (run 24295014989). All per-role
+TableWildcard grants deployed successfully. Confirmed 2026-04-11.

--- a/spec/2026-04-11-iac-integrated/06-lf-admin-config.md
+++ b/spec/2026-04-11-iac-integrated/06-lf-admin-config.md
@@ -1,0 +1,204 @@
+# Lake Formation Grants Must Be Opt-In
+
+## Scope
+
+This spec is about **Athena and Iceberg database access** under Lake
+Formation enforcement. It has nothing to do with Benchling. The affected
+databases are:
+
+- **UserAthenaDatabase** — per-bucket Athena tables created dynamically
+  by the Registry at runtime
+- **IcebergDatabase** — package_revision, package_entry, etc. created
+  at runtime by the Iceberg Lambda
+
+When Lake Formation enforcement is active at the account level, roles
+lose access to dynamically-created tables in these databases unless they
+have explicit LF grants. The grants that restore access (per-role
+TableWildcard) require the deploying role to be an LF admin — a
+prerequisite that varies by account and cannot be assumed.
+
+## Problem
+
+`lakeformation.py:add_iam_fallthrough()` unconditionally emits per-role
+TableWildcard grants for UserAthenaDatabase and IcebergDatabase. These
+grants require the CloudFormation execution role to be a Lake Formation
+admin (spec 03, 04, 05). If it isn't, the stack fails with
+AccessDeniedException on every TableWildcard `AWS::LakeFormation::Permissions`
+resource.
+
+This means **any account that hasn't completed the manual LF admin
+bootstrap (spec 04, 05) will fail to deploy**. That includes:
+
+- New customer installs (no LF admin list setup yet)
+- Accounts that don't use LF enforcement at all
+- Accounts where a different role (not the CFN role) is the LF admin
+- Any deployment where the LF admin prerequisite hasn't been met
+
+The per-role TableWildcard grants are only needed when:
+
+1. LF enforcement is active (IAM_ALLOWED_PRINCIPALS removed from defaults)
+2. The stack creates databases with dynamically-created tables
+3. The deploying role has been added to the LF admin list
+
+All three conditions are account-specific. Baking the grants in
+unconditionally turns a per-account prerequisite into a universal
+deployment blocker.
+
+## Solution
+
+Gate the per-role TableWildcard grants behind an opt-in CloudFormation
+parameter. Default to `Disabled`. Terraform sets it to `Enabled` only
+after the deploying role has been confirmed as an LF admin.
+
+## Tasks
+
+### 1. Add CFT parameter `EnableLakeFormationGrants`
+
+- Add a `Parameter` to the Quilt stack template:
+  - Name: `EnableLakeFormationGrants`
+  - Type: `String`
+  - AllowedValues: `Enabled`, `Disabled`
+  - Default: `Disabled`
+  - Description: "Enable per-role Lake Formation TableWildcard grants.
+    Requires the CloudFormation execution role to be a Lake Formation
+    administrator. Leave Disabled unless LF enforcement is active and
+    the deploying role is on the LF admin list."
+- Add a corresponding CFN condition: `LakeFormationGrantsEnabled`
+
+### 2. Gate TableWildcard grants on the new condition
+
+`lakeformation.py` is troposphere code that runs at **build time** to
+emit a CFN template. A CFN condition is evaluated at **deploy time**.
+You cannot use a CFN condition to skip a Python loop — the resources
+must be emitted into the template with a `Condition` attached so
+CloudFormation skips them at deploy time.
+
+The existing pattern (see `benchling.py:42-49`, `lakeformation.py:113-117`):
+
+```python
+# benchling.py:42 — define the condition
+cft.add_condition("BenchlingEnabled", Equals(param.ref(), "Enabled"))
+
+# benchling.py:49 — attach to each resource
+ec2.SecurityGroup(..., Condition="BenchlingEnabled")
+
+# lakeformation.py:116-117 — attach condition to grant after creation
+if hasattr(role_resource, "Condition"):
+    perm.Condition = role_resource.Condition
+```
+
+Implementation for `lakeformation.py:add_iam_fallthrough()`:
+
+- The function already receives `cft`. Add the `EnableLakeFormationGrants`
+  parameter and `LakeFormationGrantsEnabled` condition at the top of
+  `add_iam_fallthrough()` (or in the caller that sets up parameters).
+- In the `_DYNAMIC_DB_ROLE_GRANTS` loop (`lakeformation.py:90-119`),
+  attach `Condition="LakeFormationGrantsEnabled"` to every emitted
+  `lakeformation.Permissions` resource. For roles that already have
+  their own condition (e.g. `BenchlingEnabled`), the condition must be
+  the existing role condition — but since the entire grant is only
+  relevant when LF grants are enabled, those roles' grants should
+  not exist at all when LF grants are disabled. Use `troposphere.And`
+  to combine: `perm.Condition = "LFAndRoleCondition"` where that
+  condition is defined as `And(Condition("LakeFormationGrantsEnabled"), Condition(...))`.
+- Database-level and per-table IAM_ALLOWED_PRINCIPALS grants
+  (`lakeformation.py:66-85`, `124-142`) remain unconditional — they
+  don't require LF admin and don't fail.
+
+### 3. Add Terraform variable and wiring — DONE
+
+**PR:** quiltdata/iac#104
+
+- Added `enable_lf_grants` (bool, default `false`) to `modules/quilt/variables.tf`
+- Wired to CFT parameter in `modules/quilt/main.tf`:
+  `EnableLakeFormationGrants = var.enable_lf_grants ? "Enabled" : "Disabled"`
+- Documented in `VARIABLES.md` under "Lake Formation Variables"
+- Operators must set `enable_lf_grants = true` only after adding the
+  deploying role to the LF admin list (manual console step or bootstrap
+  script).
+
+### 4. Test with auto-stack-dev before merging
+
+The `bench` workspace in `tf/auto-stack-dev` is the deployment that
+needs LF grants (account 712023778557, us-east-2, where LF enforcement
+is active and GitHub-Deployment is already an LF admin per spec 05).
+
+#### Setup
+
+1. In `deployment/tf/auto-stack-dev/main.tf`, temporarily change the
+   module source ref to point at the branch:
+
+   ```hcl
+   source = "github.com/quiltdata/iac//modules/quilt?ref=2026-04-11-enable-lf-grants"
+   ```
+
+   (currently `?ref=f03d8505cd412d6847203bdde8244b92d483c8fc`)
+2. Run `terraform init -upgrade` to pull the branch ref.
+
+#### Test A: Disabled (default) — LF grants skipped at deploy time
+
+1. Do NOT add `enable_lf_grants` (or set it explicitly to `false`).
+2. Run `terraform plan` in the `bench` workspace.
+3. Verify that `EnableLakeFormationGrants = Disabled` appears in the
+   parameter list.
+4. Inspect the generated CFT and confirm the `*TableWildcardLF`
+   resources are **present** in the template but each has
+   `Condition: LakeFormationGrantsEnabled` (or a combined condition
+   for roles that have their own condition). The resources are always
+   emitted — CloudFormation skips them at deploy time when the
+   condition is false.
+5. Run `terraform apply` and confirm the stack update succeeds
+   without creating any `AWS::LakeFormation::Permissions`
+   TableWildcard resources (no AccessDeniedException, no LF grants
+   in the console).
+
+#### Test B: Enabled — LF grants deploy successfully
+
+1. Add `enable_lf_grants = true` to the module block.
+2. Run `terraform plan` in the `bench` workspace.
+3. Verify that `EnableLakeFormationGrants = Enabled` appears in the
+   parameter list.
+4. Run `terraform apply` to deploy the stack update.
+5. Confirm the CloudFormation stack update succeeds — all per-role
+   TableWildcard `AWS::LakeFormation::Permissions` resources
+   (e.g. `UserAthenaDatabaseAmazonECSTaskExecutionRoleTableWildcardLF`,
+   `IcebergDatabaseIcebergLambdaRoleTableWildcardLF`, etc.) create
+   without AccessDeniedException.
+6. Spot-check in the AWS console (Lake Formation > Data permissions)
+   that the expected roles have TableWildcard grants on
+   UserAthenaDatabase and IcebergDatabase.
+
+#### Cleanup
+
+1. Revert the source ref change — the real merge will use a commit
+   SHA or tag on main.
+
+### 5. Document the bootstrap sequence
+
+- Update deployment docs to include the correct order of operations:
+  1. Deploy stack with `EnableLakeFormationGrants = Disabled` (default)
+  2. Add the CFN execution role to the LF admin list (manual/console)
+  3. Set `enable_lf_grants = true` in Terraform and redeploy
+- Note: steps 2-3 are only needed when LF enforcement is active.
+  Accounts without LF enforcement can leave the parameter disabled
+  permanently with no loss of functionality (IAM policies are
+  sufficient).
+
+### 6. Verify no other LF-admin-dependent resources leak through
+
+- Audit `lakeformation.py` for any other resources that implicitly
+  require LF admin privileges (e.g. `DataLakeSettings` modifications).
+- Confirm that database-level `IAM_ALLOWED_PRINCIPALS` grants and
+  per-table `IAM_ALLOWED_PRINCIPALS` grants do NOT require LF admin
+  (they use the built-in IAM fallthrough mechanism).
+- If any are found, gate them behind the same condition.
+
+## Non-goals
+
+- Automating the LF admin bootstrap (chicken-and-egg problem from
+  spec 04 remains manual by design).
+- Standalone benchling-webhook CDK stack — it doesn't manage Athena
+  or Iceberg databases and has no LF grants. If it ever adds them,
+  gate behind a similar opt-in parameter at that time.
+- Modifying account-level `DataLakeSettings` (CreateTableDefaultPermissions
+  etc.) from the stack template.

--- a/test/benchling-webhook-stack.test.ts
+++ b/test/benchling-webhook-stack.test.ts
@@ -44,18 +44,10 @@ describe("BenchlingWebhookStack", () => {
     });
 
     test("creates EventBridge package revision rule and API target", () => {
-        template.hasParameter("PackagePrefix", {
-            Default: "benchling",
-        });
-
         template.hasResourceProperties("AWS::Events::Rule", {
             EventPattern: {
                 source: ["com.quiltdata"],
                 "detail-type": ["package-revision"],
-                detail: {
-                    bucket: [{ Ref: "PackageBucket" }],
-                    handle: [{ prefix: { "Fn::Join": ["", [{ Ref: "PackagePrefix" }, "/"]] } }],
-                },
             },
             Targets: Match.arrayWith([
                 Match.objectLike({


### PR DESCRIPTION
## Summary

- Simplifies EventBridge rule to match only `source` + `detail-type` — removes `detail.bucket` and `detail.handle` prefix filter that depended on deploy-time values derived from Secrets Manager
- Adds runtime prefix filtering in the Docker handler (`app.py`) alongside the existing bucket check
- Removes the `PackagePrefix` CloudFormation parameter (no longer needed)
- Unblocks integrated-mode stacks where the Quilt IaC creates the EventBridge rule independently
- Removes pending canvas state — the intermediate "Updating..." canvas with disabled buttons, stripped links, and spurious Athena queries was a net negative; the canvas now stays unchanged until the EventBridge package event confirms the update
- Canvas footer now shows "Pending update" (honest) instead of "Up to date" (misleading) when no confirmed timestamp exists

## Companion PR

- quiltdata/deployment#2361 — adds EventBridge rule to Quilt stack IaC for integrated mode

## Context

See [spec/2026-04-11-iac-integrated/01-iac-breakage.md](spec/2026-04-11-iac-integrated/01-iac-breakage.md) for the full analysis.

## Test plan

- [x] `npm test` — 380 Python tests pass
- [x] Pending canvas tests removed/simplified (no longer applicable)
- [x] Footer tests updated for "Pending update" wording
- [x] `npm run test:integration` — integration tests
- [x] `npm run test:local` — Docker build + webhook tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)