### PR TITLE
fix: 0.17.2 — sqs_consumer secrets wait, FIFO packaging, canvas updating UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-04-15
+
+### Fixed
+
+- SQS consumer now waits for Benchling secrets to be populated instead of crashing on fresh deploys. Previously, an empty `BenchlingSecret` (populated later by the external config script) caused `SecretsManagerError` at startup, repeated task failures, and tripped the ECS deployment circuit breaker. The consumer now installs signal handlers first, then loops with bounded exponential backoff (30s → 300s) until secrets load, short-circuiting cleanly on SIGTERM
+- `MaxNumberOfMessages` is now capped at `min(10, concurrency)` so tail messages no longer sit in the semaphore backlog eating visibility timeout
+
 ## [0.17.0] - 2026-04-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-04-15
+
+### Fixed
+
+- Canvas during entry export now shows the full navigation layout (Browse/Update buttons, package header, and footer reading "Updating...") instead of a bare "Processing..." placeholder. Update Package is disabled while the export runs; Browse Package stays enabled so the previous package version remains reachable on re-exports
+- Packaging requests are now sequenced per entry through a FIFO SQS queue, so `entry.created` and `canvas.created` events for the same entry can no longer race and drop `canvas_id` from `entry.json`
+
+### Removed
+
+- `.canvas_id` S3 sidecar is no longer read or written — per-entry FIFO ordering makes it unnecessary. Existing sidecar objects in S3 from prior deployments are harmless orphans
+
 ## [0.17.1] - 2026-04-15
 
 ### Fixed

--- a/docker/app-manifest.yaml
+++ b/docker/app-manifest.yaml
@@ -2,7 +2,7 @@ manifestVersion: 1
 info:
   name: nightly-quilttest-com
   description: Packaging Benchling Notebooks as Quilt packages
-  version: 0.17.0
+  version: 0.17.1
 features:
   - name: Quilt Connector
     id: quilt_entry

--- a/docker/app-manifest.yaml
+++ b/docker/app-manifest.yaml
@@ -2,7 +2,7 @@ manifestVersion: 1
 info:
   name: nightly-quilttest-com
   description: Packaging Benchling Notebooks as Quilt packages
-  version: 0.17.1
+  version: 0.17.2
 features:
   - name: Quilt Connector
     id: quilt_entry

--- a/docker/pyproject.toml
+++ b/docker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "benchling-quilt-integration"
-version = "0.17.1"
+version = "0.17.2"
 description = "Benchling-Quilt Integration Webhook Service"
 license = {text = "Apache-2.0"}
 authors = [

--- a/docker/pyproject.toml
+++ b/docker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "benchling-quilt-integration"
-version = "0.17.0"
+version = "0.17.1"
 description = "Benchling-Quilt Integration Webhook Service"
 license = {text = "Apache-2.0"}
 authors = [

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -18,6 +18,11 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from .canvas import CanvasManager
 from .config import Config, get_config
 from .entry_packager import EntryPackager
+from .packaging_publisher import (
+    PackagingQueueNotConfiguredError,
+    get_packaging_queue_url,
+    publish_packaging_request,
+)
 from .payload import Payload
 from .secrets_manager import SecretsManagerError
 from .version import __version__
@@ -206,6 +211,7 @@ def create_app() -> FastAPI:
     config: Config | None = None
     benchling: Benchling | None = None
     entry_packager: EntryPackager | None = None
+    packaging_queue_url: str | None = None
     startup_problem: Dict[str, Any] | None = None
     jwks_http_client: httpx.Client | None = None
 
@@ -266,7 +272,8 @@ def create_app() -> FastAPI:
 
     def _initialize_runtime() -> None:
         """Initialize configuration and clients, recording secret-related failures."""
-        nonlocal config, benchling, entry_packager, jwks_fetcher_with_caching, jwks_http_client
+        nonlocal config, benchling, entry_packager, packaging_queue_url
+        nonlocal jwks_fetcher_with_caching, jwks_http_client
 
         try:
             config = get_config()
@@ -419,6 +426,22 @@ def create_app() -> FastAPI:
                 benchling=benchling,
                 config=config,
             )
+
+            # Resolve packaging-request FIFO queue URL. Required in production
+            # so webhook handlers can enqueue work; missing env var is a
+            # configuration problem we want to surface clearly at startup.
+            try:
+                packaging_queue_url = get_packaging_queue_url()
+                logger.info(
+                    "Packaging-request queue configured",
+                    queue_url=packaging_queue_url,
+                )
+            except PackagingQueueNotConfiguredError as exc:
+                record_startup_problem(exc, "packaging_queue")
+                logger.warning(
+                    "PACKAGING_REQUEST_QUEUE_URL not set - webhook will reject "
+                    "events until this env var is configured"
+                )
 
             # Validate role assumption at startup (blocking - fail fast)
             role_arn = getattr(config, "quilt_write_role_arn", None)
@@ -669,6 +692,24 @@ def create_app() -> FastAPI:
         )
         return JSONResponse(build_secret_unavailable_body(), status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
 
+    def _send_updating_canvas_best_effort(payload: Payload) -> None:
+        """Send the immediate 'Updating...' canvas before enqueuing the workflow.
+
+        Best-effort: any failure is logged but does not block the publish, so
+        the user always sees the workflow start (just maybe without the
+        intermediate placeholder).
+        """
+        if not payload.canvas_id or benchling is None or config is None:
+            return
+        try:
+            CanvasManager(benchling, config, payload).send_updating_canvas()
+        except Exception as exc:
+            logger.warning(
+                "Failed to send initial 'Updating...' canvas",
+                canvas_id=payload.canvas_id,
+                error=str(exc),
+            )
+
     async def _handle_event_impl(request: Request, _verified: None = None):
         """Shared event webhook handling implementation."""
         try:
@@ -677,6 +718,7 @@ def create_app() -> FastAPI:
                 return blocked_response
 
             assert benchling is not None and entry_packager is not None and config is not None
+            assert packaging_queue_url is not None, "packaging_queue_url must be set when not in degraded mode"
 
             logger.info("Received /event", headers=dict(request.headers))
             payload = await Payload.from_request(request, benchling)
@@ -695,8 +737,8 @@ def create_app() -> FastAPI:
                     event_type=payload.event_type,
                     canvas_id=payload.canvas_id,
                 )
-                logger.debug("Starting background export workflow from /event", entry_id=payload.entry_id)
-                entry_packager.execute_workflow_async(payload)
+                _send_updating_canvas_best_effort(payload)
+                publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
 
                 logger.info("Canvas update initiated from /event endpoint", canvas_id=payload.canvas_id)
                 return JSONResponse(
@@ -716,17 +758,16 @@ def create_app() -> FastAPI:
                     "message": f"Event type {payload.event_type} not processed",
                 }
 
-            logger.debug("Starting background export workflow for entry event", entry_id=payload.entry_id)
-            entry_id = entry_packager.execute_workflow_async(payload)
+            publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
 
             logger.info(
-                "Entry event processed - workflow started",
-                entry_id=entry_id,
+                "Entry event processed - packaging request enqueued",
+                entry_id=payload.entry_id,
                 event_type=payload.event_type,
             )
 
             return {
-                "entry_id": entry_id,
+                "entry_id": payload.entry_id,
                 "status": "ACCEPTED",
                 "message": "Workflow started successfully",
                 "orchestration": "python",
@@ -821,6 +862,7 @@ def create_app() -> FastAPI:
                 return blocked_response
 
             assert benchling is not None and entry_packager is not None and config is not None
+            assert packaging_queue_url is not None, "packaging_queue_url must be set when not in degraded mode"
 
             logger.info("Received /canvas", headers=dict(request.headers))
             payload = await Payload.from_request(request, benchling)
@@ -855,19 +897,19 @@ def create_app() -> FastAPI:
 
                 logger.warning("Unknown button action from /canvas", button_id=button_id)
 
-            logger.debug("Starting background export workflow", entry_id=payload.entry_id)
-            execution_arn = entry_packager.execute_workflow_async(payload)
+            _send_updating_canvas_best_effort(payload)
+            sqs_message_id = publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
 
             logger.info(
                 "Canvas update initiated",
                 canvas_id=payload.canvas_id,
                 entry_id=payload.entry_id,
                 event_type=payload.event_type,
-                execution_arn=execution_arn,
+                sqs_message_id=sqs_message_id,
             )
 
             return JSONResponse(
-                {"status": "ACCEPTED", "message": "Canvas update initiated", "execution_arn": execution_arn},
+                {"status": "ACCEPTED", "message": "Canvas update initiated", "sqs_message_id": sqs_message_id},
                 status_code=202,
             )
 
@@ -1134,8 +1176,9 @@ def create_app() -> FastAPI:
     def handle_update_package(payload, entry_packager, benchling, config):
         """Handle Update Package button click (existing functionality)."""
         logger.info("Update package requested", entry_id=payload.entry_id)
+        assert packaging_queue_url is not None, "packaging_queue_url must be set when not in degraded mode"
 
-        execution_arn = entry_packager.execute_workflow_async(payload)
+        sqs_message_id = publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
 
         canvas_manager = CanvasManager(benchling, config, payload)
         canvas_manager.handle_async()
@@ -1144,7 +1187,7 @@ def create_app() -> FastAPI:
             {
                 "status": "ACCEPTED",
                 "message": "Package update started!",
-                "execution_arn": execution_arn,
+                "sqs_message_id": sqs_message_id,
             },
             status_code=202,
         )

--- a/docker/src/canvas.py
+++ b/docker/src/canvas.py
@@ -235,22 +235,36 @@ class CanvasManager:
 
         return content
 
-    def _make_blocks(self, updated_at: str | None = None) -> list:
+    def _make_blocks(self, updated_at: str | None = None, is_updating: bool = False) -> list:
         """Create UI blocks for the Canvas.
 
         Args:
             updated_at: ISO timestamp of last package update
+            is_updating: If True, render the "regular" layout with an "Updating..."
+                footer and skip slow metadata queries (linked packages). Used for
+                the initial acknowledgment canvas shown before the workflow runs.
         """
-        markdown_content = self._make_markdown_content()
+        if is_updating:
+            # Render only the primary package header — skip the Athena query for
+            # linked packages so the initial update returns quickly.
+            markdown_content = fmt.format_package_header(
+                package_name=self.package_name,
+                display_id=self.entry.display_id,
+                catalog_url=self.catalog_url,
+                sync_url=self.sync_uri(),
+            )
+        else:
+            markdown_content = self._make_markdown_content()
+
         markdown_block = blocks.create_markdown_block(markdown_content, "md1")
 
         result = [
-            *blocks.create_main_navigation_buttons(self.entry_id),
+            *blocks.create_main_navigation_buttons(self.entry_id, update_enabled=not is_updating),
             markdown_block,
         ]
 
-        # Add linked package browse buttons if any exist
-        if self._linked_packages:
+        # Add linked package browse buttons if any exist (skipped during initial update)
+        if not is_updating and self._linked_packages:
             result.extend(blocks.create_linked_package_browse_buttons(self.entry_id, self._linked_packages))
 
         # Add footer as markdown block
@@ -259,6 +273,7 @@ class CanvasManager:
             quilt_host=self.config.quilt_catalog,
             bucket=self.config.s3_bucket_name,
             updated_at=updated_at,
+            is_updating=is_updating,
         )
         result.append(blocks.create_markdown_block(footer_markdown, "md-footer"))
 
@@ -633,22 +648,23 @@ class CanvasManager:
         """Handle Canvas webhook payload asynchronously in background thread."""
         threading.Thread(target=self._handle, daemon=True).start()
 
-    @staticmethod
-    def send_processing_update(benchling: Benchling, canvas_id: str) -> dict[str, Any]:
-        """Send a 'Processing...' canvas update. Best-effort, does not raise.
+    def send_updating_canvas(self) -> dict[str, Any]:
+        """Send the regular canvas layout with an 'Updating...' footer.
 
-        Called synchronously on the request thread to provide immediate feedback
-        when a canvas is first created, before the background workflow runs.
+        Best-effort, does not raise. Called synchronously on the request thread
+        to provide immediate feedback with the same layout as the final view —
+        the background workflow will later call ``update_canvas`` with full
+        linked-package data and an 'Updated at' timestamp.
         """
         try:
-            processing_blocks = blocks.create_processing_blocks()
+            updating_blocks = self._make_blocks(is_updating=True)
             canvas_update = AppCanvasUpdate(
-                blocks=processing_blocks,  # type: ignore
+                blocks=updating_blocks,  # type: ignore
                 enabled=True,  # type: ignore
             )
-            result = benchling.apps.update_canvas(canvas_id=canvas_id, canvas=canvas_update)
-            logger.info("Sent processing acknowledgment", canvas_id=canvas_id)
-            return {"success": True, "canvas_id": getattr(result, "id", canvas_id)}
+            result = self.benchling.apps.update_canvas(canvas_id=self.canvas_id, canvas=canvas_update)
+            logger.info("Sent 'Updating...' canvas acknowledgment", canvas_id=self.canvas_id)
+            return {"success": True, "canvas_id": getattr(result, "id", self.canvas_id)}
         except Exception as e:
-            logger.warning("Failed to send processing acknowledgment", canvas_id=canvas_id, error=str(e))
+            logger.warning("Failed to send 'Updating...' canvas", canvas_id=self.canvas_id, error=str(e))
             return {"success": False, "error": str(e)}

--- a/docker/src/canvas_blocks.py
+++ b/docker/src/canvas_blocks.py
@@ -90,23 +90,15 @@ def create_section(section_id: str, buttons: List[ButtonUiBlock]) -> SectionUiBl
     )
 
 
-def create_processing_blocks() -> List:
-    """Create canvas blocks showing a 'Processing...' state.
-
-    Used to provide immediate feedback when a canvas is first created,
-    before the export workflow completes.
-
-    Returns:
-        List containing a markdown block with processing message
-    """
-    return [create_markdown_block("**Processing...**\n\nExporting entry and creating package.", "md-processing")]
-
-
-def create_main_navigation_buttons(entry_id: str) -> List:
+def create_main_navigation_buttons(entry_id: str, update_enabled: bool = True) -> List:
     """Create main view navigation buttons (Browse Package, Update Package).
 
     Args:
         entry_id: Entry identifier for button IDs
+        update_enabled: If False, render the 'Update Package' button as disabled.
+            Used during the initial 'Updating...' state so a second click cannot
+            spawn a concurrent export workflow. Browse stays enabled — on a
+            re-export the previous package version is still valid.
 
     Returns:
         List containing section with navigation buttons
@@ -119,6 +111,7 @@ def create_main_navigation_buttons(entry_id: str) -> List:
         create_button(
             button_id=f"update-package-{entry_id}",
             text="Update Package",
+            enabled=update_enabled,
         ),
     ]
 

--- a/docker/src/canvas_formatting.py
+++ b/docker/src/canvas_formatting.py
@@ -265,7 +265,13 @@ def dict_to_markdown_list(data: Dict[str, Any], indent_level: int = 0) -> str:
     return md
 
 
-def format_canvas_footer(version: str, quilt_host: str, bucket: str, updated_at: str | None = None) -> str:
+def format_canvas_footer(
+    version: str,
+    quilt_host: str,
+    bucket: str,
+    updated_at: str | None = None,
+    is_updating: bool = False,
+) -> str:
     """Format canvas footer with version and deployment information.
 
     Args:
@@ -273,11 +279,14 @@ def format_canvas_footer(version: str, quilt_host: str, bucket: str, updated_at:
         quilt_host: Quilt catalog host
         bucket: S3 bucket name
         updated_at: ISO timestamp of last package update
+        is_updating: If True, show 'Updating...' status (overrides updated_at)
 
     Returns:
         Formatted markdown string with footer information
     """
-    if updated_at:
+    if is_updating:
+        status = "⏳ *Updating...*"
+    elif updated_at:
         status = f"✅ *Updated at {updated_at}*"
     else:
         status = "⏳ *Pending update*"

--- a/docker/src/entry_packager.py
+++ b/docker/src/entry_packager.py
@@ -949,11 +949,20 @@ For questions about the data, refer to the original Benchling entry.
             package_name_preview=package_name_preview,
         )
 
-        # Send immediate "Processing..." feedback if this is a canvas event
+        # Send immediate regular-layout canvas (with "Updating..." footer) if this
+        # is a canvas event. The background workflow will later refresh it with
+        # linked-package data and an "Updated at" timestamp.
         if payload.canvas_id and self.benchling:
             from .canvas import CanvasManager
 
-            CanvasManager.send_processing_update(self.benchling, payload.canvas_id)
+            try:
+                CanvasManager(self.benchling, self.config, payload).send_updating_canvas()
+            except Exception as e:
+                self.logger.warning(
+                    "Failed to send initial 'Updating...' canvas",
+                    canvas_id=payload.canvas_id,
+                    error=str(e),
+                )
 
         # Execute workflow in background thread
         def background_execution():

--- a/docker/src/entry_packager.py
+++ b/docker/src/entry_packager.py
@@ -7,7 +7,6 @@ and queues them for Quilt package creation via SQS.
 
 import io
 import json
-import threading
 import time
 import zipfile
 from datetime import datetime, timezone
@@ -47,6 +46,22 @@ class EntryValidationError(ValueError):
     """Exception raised when entry data validation fails."""
 
     pass
+
+
+def _format_commit_message(payload: Payload) -> str:
+    """Build the Quilt package commit message from a Benchling webhook payload.
+
+    Includes the event type so revisions are self-explanatory in the Quilt UI
+    (e.g., distinguishing ``v2.entry.updated.reviewRecord`` from
+    ``v2.entry.created``). Appends the event timestamp when present; drops it
+    cleanly when missing so the message never trails with a dangling separator.
+    """
+    event = payload.event_type or "webhook payload"
+    message = f"Benchling {event}"
+    timestamp = payload.timestamp
+    if timestamp:
+        message += f" at {timestamp}"
+    return message
 
 
 def validate_entry_data(entry_data: Dict[str, Any], entry_id: str) -> Dict[str, Any]:
@@ -470,13 +485,12 @@ class EntryPackager:
             uploaded_files = []
             canvas_id = payload.canvas_id
 
-            # If canvas_id comes from a canvas event, persist it to a dedicated
-            # sidecar file so entry events (which have no canvas_id) can't
-            # overwrite it via the race on entry.json.
-            if canvas_id is not None:
-                self._save_canvas_id(s3_client, package_name, canvas_id)
-            else:
-                canvas_id = self._load_canvas_id(s3_client, package_name)
+            # When this event has no canvas_id (e.g., a v2.entry.* event),
+            # preserve any canvas_id already recorded by an earlier canvas
+            # event for the same package. Sequential FIFO processing per
+            # entry_id makes a plain S3 read sufficient — no sidecar needed.
+            if canvas_id is None:
+                canvas_id = self._load_existing_canvas_id_from_entry_json(s3_client, package_name)
 
             # Extract and upload files from ZIP
             self.logger.info("Extracting and uploading files from in-memory ZIP buffer")
@@ -499,12 +513,6 @@ class EntryPackager:
                             "size": len(file_content),
                         }
                     )
-
-            # Re-read canvas_id right before writing to minimize the race window.
-            # Another thread (canvas event) may have written .canvas_id since we
-            # last checked.
-            if canvas_id is None:
-                canvas_id = self._load_canvas_id(s3_client, package_name)
 
             # Create metadata files (entry_data already fetched above)
             metadata_files = self._create_metadata_files(
@@ -698,70 +706,41 @@ For questions about the data, refer to the original Benchling entry.
             "README.md": readme_content,
         }
 
-    def _save_canvas_id(self, s3_client: Any, package_name: str, canvas_id: str) -> None:
-        """Write canvas_id to a dedicated sidecar file in S3.
+    def _load_existing_canvas_id_from_entry_json(self, s3_client: Any, package_name: str) -> Optional[str]:
+        """Read canvas_id from a previously-written ``entry.json``, if any.
 
-        Only called when canvas_id comes from a canvas event payload.
-        Entry events never write this file, which prevents the race condition
-        where an entry event overwrites a canvas event's canvas_id.
+        Used when the current event has no ``canvas_id`` (e.g., a v2.entry.*
+        event) but a prior canvas event for the same entry already recorded
+        one. FIFO sequencing on ``entry_id`` guarantees that prior write is
+        visible by the time we run.
         """
-        s3_key = f"{package_name}/.canvas_id"
-        try:
-            s3_client.put_object(
-                Bucket=self.config.s3_bucket_name,
-                Key=s3_key,
-                Body=canvas_id.encode("utf-8"),
-            )
-            self.logger.info("Saved canvas_id to sidecar file", package_name=package_name, canvas_id=canvas_id)
-        except Exception as exc:
-            self.logger.warning(
-                "Failed to save canvas_id sidecar file",
-                package_name=package_name,
-                canvas_id=canvas_id,
-                error=str(exc),
-            )
-
-    def _load_canvas_id(self, s3_client: Any, package_name: str) -> Optional[str]:
-        """Load canvas_id from S3, checking sidecar file first then entry.json."""
-        # Primary: dedicated sidecar file (written only by canvas events)
-        sidecar_key = f"{package_name}/.canvas_id"
-        try:
-            response = s3_client.get_object(Bucket=self.config.s3_bucket_name, Key=sidecar_key)
-            canvas_id = response["Body"].read().decode("utf-8").strip()
-            if canvas_id:
-                self.logger.debug("Loaded canvas_id from sidecar file", package_name=package_name)
-                return canvas_id
-        except Exception as exc:
-            error_code = getattr(exc, "response", {}).get("Error", {}).get("Code")
-            if error_code not in {"NoSuchKey", "404"}:
-                self.logger.debug("Failed to read .canvas_id sidecar", error=str(exc))
-
-        # Fallback: entry.json (backward compat for packages created before sidecar)
         entry_key = f"{package_name}/entry.json"
         try:
             response = s3_client.get_object(Bucket=self.config.s3_bucket_name, Key=entry_key)
-            body = response["Body"].read().decode("utf-8")
-            metadata = json.loads(body)
+            metadata = json.loads(response["Body"].read().decode("utf-8"))
             if isinstance(metadata, dict):
                 canvas_id = metadata.get("canvas_id")
                 if isinstance(canvas_id, str) and canvas_id:
-                    self.logger.debug("Loaded canvas_id from entry.json fallback", package_name=package_name)
+                    self.logger.debug("Preserved canvas_id from existing entry.json", package_name=package_name)
                     return canvas_id
         except Exception as exc:
             error_code = getattr(exc, "response", {}).get("Error", {}).get("Code")
             if error_code not in {"NoSuchKey", "404"}:
-                self.logger.debug("Failed to read entry.json for canvas_id", error=str(exc))
-
+                self.logger.debug(
+                    "Failed to read entry.json for canvas_id preservation",
+                    package_name=package_name,
+                    error=str(exc),
+                )
         return None
 
     @REST_API_RETRY
-    def _send_to_sqs(self, package_name: str, timestamp: str) -> Dict[str, Any]:
+    def _send_to_sqs(self, package_name: str, payload: Payload) -> Dict[str, Any]:
         """
         Send package creation message to Quilt SQS queue.
 
         Args:
             package_name: Quilt package name
-            timestamp: Event timestamp for commit message
+            payload: Parsed webhook payload (used to build the commit message)
 
         Returns:
             SQS response with MessageId
@@ -777,7 +756,7 @@ For questions about the data, refer to the original Benchling entry.
             "registry": self.config.s3_bucket_name,
             "package_name": package_name,
             "metadata_uri": "entry.json",
-            "commit_message": f"Benchling webhook payload - {timestamp}",
+            "commit_message": _format_commit_message(payload),
         }
         if getattr(self.config, "workflow", ""):
             message_body["workflow"] = self.config.workflow
@@ -869,7 +848,7 @@ For questions about the data, refer to the original Benchling entry.
             )
 
             # Step 5: Send to Quilt queue
-            sqs_result = self._send_to_sqs(package_name, payload.timestamp or "")
+            sqs_result = self._send_to_sqs(package_name, payload)
             self.logger.debug(
                 "SQS message sent",
                 message_id=sqs_result.get("MessageId"),
@@ -879,7 +858,7 @@ For questions about the data, refer to the original Benchling entry.
             # This provides an optimistic preview; the SQS consumer will send the
             # authoritative update once Quilt creates the package revision.
             s3_client = self.role_manager.get_s3_client()
-            canvas_id = payload.canvas_id or self._load_canvas_id(s3_client, package_name)
+            canvas_id = payload.canvas_id or self._load_existing_canvas_id_from_entry_json(s3_client, package_name)
             if canvas_id and self.benchling:
                 try:
                     from .canvas import CanvasManager
@@ -923,86 +902,3 @@ For questions about the data, refer to the original Benchling entry.
             )
 
             raise
-
-    def execute_workflow_async(self, payload: Payload) -> str:
-        """
-        Execute workflow asynchronously in background thread.
-
-        This prevents blocking the webhook response while workflow executes.
-
-        Args:
-            payload: Parsed webhook payload
-
-        Returns:
-            Task identifier (entry_id) for reference
-        """
-        entry_id = payload.entry_id
-        # Note: display_id will be fetched and set during workflow execution
-        # Use entry_id for initial logging, display_id-based package name will be used later
-        package_name_preview = payload.package_name(self.config.s3_prefix, use_display_id=False)
-
-        self.logger.info(
-            "Package entries workflow scheduled",
-            entry_id=entry_id,
-            event_id=payload.event_id,
-            event_type=payload.event_type,
-            package_name_preview=package_name_preview,
-        )
-
-        # Send immediate regular-layout canvas (with "Updating..." footer) if this
-        # is a canvas event. The background workflow will later refresh it with
-        # linked-package data and an "Updated at" timestamp.
-        if payload.canvas_id and self.benchling:
-            from .canvas import CanvasManager
-
-            try:
-                CanvasManager(self.benchling, self.config, payload).send_updating_canvas()
-            except Exception as e:
-                self.logger.warning(
-                    "Failed to send initial 'Updating...' canvas",
-                    canvas_id=payload.canvas_id,
-                    error=str(e),
-                )
-
-        # Execute workflow in background thread
-        def background_execution():
-            try:
-                self.logger.info(
-                    "Background workflow execution started",
-                    entry_id=entry_id,
-                    event_type=payload.event_type,
-                )
-
-                # Execute all workflow steps
-                result = self.execute_workflow(payload)
-
-                self.logger.info(
-                    "Background workflow execution completed successfully",
-                    entry_id=entry_id,
-                    package_name=result.get("packageName"),
-                    result_status=result.get("status"),
-                )
-
-            except Exception as e:
-                error_message = str(e)
-                error_cause = e.__class__.__name__
-
-                self.logger.error(
-                    "Background workflow execution failed",
-                    entry_id=entry_id,
-                    error=error_message,
-                    error_type=error_cause,
-                    exc_info=True,
-                )
-
-        thread = threading.Thread(target=background_execution, daemon=True)
-        thread.start()
-
-        self.logger.debug(
-            "Background workflow thread started",
-            entry_id=entry_id,
-            thread_name=thread.name,
-            thread_id=thread.ident,
-        )
-
-        return entry_id

--- a/docker/src/package_event.py
+++ b/docker/src/package_event.py
@@ -74,27 +74,6 @@ def _classify_exception(exc: Exception) -> RefreshOutcome:
     return RefreshOutcome.TRANSIENT_ERROR
 
 
-def _load_canvas_id_sidecar(
-    package_fetcher: PackageFileFetcher,
-    package_name: str,
-    bucket: str,
-) -> str | None:
-    """Read canvas_id from the dedicated .canvas_id sidecar file in S3."""
-    s3_key = f"{package_name}/.canvas_id"
-    try:
-        s3_client = package_fetcher.role_manager.get_s3_client()
-        response = s3_client.get_object(Bucket=bucket, Key=s3_key)
-        canvas_id = response["Body"].read().decode("utf-8").strip()
-        if canvas_id:
-            logger.info("Loaded canvas_id from sidecar file", package_name=package_name)
-            return canvas_id
-    except Exception as exc:
-        error_code = getattr(exc, "response", {}).get("Error", {}).get("Code")
-        if error_code not in {"NoSuchKey", "404"}:
-            logger.debug("Failed to read .canvas_id sidecar", package_name=package_name, error=str(exc))
-    return None
-
-
 def refresh_canvas_for_package_event(
     package_name: str,
     top_hash: str | None,
@@ -129,12 +108,6 @@ def refresh_canvas_for_package_event(
         metadata = package_fetcher.get_package_metadata(package_name)
         canvas_id = metadata.get("canvas_id")
         entry_id = metadata.get("entry_id")
-
-        # Fallback: read canvas_id from dedicated sidecar file (.canvas_id).
-        # This handles the race condition where v2.entry.created overwrites
-        # entry.json before v2.canvas.created writes it.
-        if not canvas_id and entry_id:
-            canvas_id = _load_canvas_id_sidecar(package_fetcher, package_name, config.s3_bucket_name)
 
         if not canvas_id or not entry_id:
             logger.info(

--- a/docker/src/packaging_consumer.py
+++ b/docker/src/packaging_consumer.py
@@ -1,0 +1,156 @@
+"""
+Drain the FIFO packaging-request queue and run ``EntryPackager.execute_workflow``.
+
+Runs as a third Fargate sidecar container (alongside the webhook container and
+the existing package-event consumer). FIFO + ``MessageGroupId=entry_id`` makes
+this consumer process work for any single entry sequentially, eliminating the
+race condition the ``.canvas_id`` sidecar used to mask.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import time
+from typing import Any
+
+import structlog
+
+from .entry_packager import EntryPackager
+from .payload import Payload
+from .sqs_consumer import (
+    BaseSqsConsumer,
+    build_sqs_client,
+    create_benchling_client,
+    wait_for_ready_config,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class PackagingConsumer(BaseSqsConsumer):
+    """Consume FIFO packaging requests and dispatch to ``execute_workflow``."""
+
+    def __init__(
+        self,
+        *,
+        queue_url: str,
+        sqs_client: Any,
+        entry_packager: EntryPackager,
+        concurrency: int = 5,
+        graceful_timeout: int = 30,
+        stop_event: asyncio.Event | None = None,
+    ):
+        super().__init__(
+            queue_url=queue_url,
+            sqs_client=sqs_client,
+            concurrency=concurrency,
+            graceful_timeout=graceful_timeout,
+            stop_event=stop_event,
+        )
+        self.entry_packager = entry_packager
+
+    async def process_message(self, message: dict[str, Any]) -> None:
+        sqs_message_id = message.get("MessageId", "unknown")
+        receipt_handle = message.get("ReceiptHandle")
+        message_group_id = (message.get("Attributes") or {}).get("MessageGroupId")
+        start_time = time.monotonic()
+        outcome = "consumer_bug"
+        should_delete = False
+        entry_id: str | None = None
+
+        try:
+            body_str = message.get("Body") or ""
+            try:
+                raw = json.loads(body_str)
+            except json.JSONDecodeError as exc:
+                outcome = "parse_error"
+                # Permanent: a malformed body will never succeed. Delete so it
+                # does not block subsequent messages in the same MessageGroup.
+                should_delete = True
+                logger.error(
+                    "Failed to parse packaging-request body as JSON",
+                    sqs_message_id=sqs_message_id,
+                    message_group_id=message_group_id,
+                    error=str(exc),
+                )
+                return
+
+            payload = Payload(raw, benchling=self.entry_packager.benchling)
+            entry_id = payload.entry_id
+
+            await asyncio.to_thread(self.entry_packager.execute_workflow, payload)
+            outcome = "success"
+            should_delete = True
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            outcome = "workflow_error"
+            # Leave the message on the queue. Visibility timeout (40 min) plus
+            # maxReceiveCount=3 will route persistent failures to the DLQ.
+            logger.error(
+                "Packaging workflow failed; leaving message for retry",
+                sqs_message_id=sqs_message_id,
+                message_group_id=message_group_id,
+                entry_id=entry_id,
+                error=str(exc),
+                error_type=type(exc).__name__,
+                exc_info=True,
+            )
+        finally:
+            if should_delete and receipt_handle:
+                await self.delete_message(receipt_handle)
+
+            logger.info(
+                "Processed packaging request",
+                sqs_message_id=sqs_message_id,
+                message_group_id=message_group_id,
+                entry_id=entry_id,
+                duration_ms=int((time.monotonic() - start_time) * 1000),
+                outcome=outcome,
+            )
+
+
+async def main() -> int:
+    queue_url = os.getenv("PACKAGING_REQUEST_QUEUE_URL", "").strip()
+    if not queue_url:
+        logger.info("PACKAGING_REQUEST_QUEUE_URL not configured; packaging consumer exiting")
+        return 0
+
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, stop_event.set)
+        except NotImplementedError:  # pragma: no cover - platform specific
+            signal.signal(sig, lambda _signum, _frame: stop_event.set())
+
+    config = await wait_for_ready_config(stop_event)
+    if config is None:
+        logger.info("Packaging consumer stopped before Benchling secrets became available")
+        return 0
+
+    sqs_client = build_sqs_client(config.aws_region)
+    concurrency = int(os.getenv("PACKAGING_REQUEST_CONCURRENCY", "5"))
+    graceful_timeout = int(os.getenv("PACKAGING_REQUEST_GRACEFUL_TIMEOUT", "30"))
+
+    benchling = create_benchling_client(config)
+    entry_packager = EntryPackager(benchling=benchling, config=config)
+
+    consumer = PackagingConsumer(
+        queue_url=queue_url,
+        sqs_client=sqs_client,
+        entry_packager=entry_packager,
+        concurrency=concurrency,
+        graceful_timeout=graceful_timeout,
+        stop_event=stop_event,
+    )
+
+    await consumer.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/docker/src/packaging_publisher.py
+++ b/docker/src/packaging_publisher.py
@@ -1,0 +1,79 @@
+"""
+Publish packaging requests to the FIFO SQS queue.
+
+The webhook handler enqueues a message here instead of spawning a daemon
+thread. A separate consumer (``packaging_consumer``) drains the queue and
+runs ``EntryPackager.execute_workflow``. ``MessageGroupId=entry_id`` ensures
+SQS FIFO sequences all work for a single entry, eliminating the race where
+overlapping entry/canvas events trampled each other's ``entry.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import structlog
+
+from .payload import Payload
+
+logger = structlog.get_logger(__name__)
+
+
+PACKAGING_REQUEST_QUEUE_URL_ENV = "PACKAGING_REQUEST_QUEUE_URL"
+
+
+class PackagingQueueNotConfiguredError(RuntimeError):
+    """Raised when the packaging-request queue URL env var is missing."""
+
+
+def get_packaging_queue_url() -> str:
+    """Return the configured packaging-request queue URL or raise."""
+    url = os.getenv(PACKAGING_REQUEST_QUEUE_URL_ENV, "").strip()
+    if not url:
+        raise PackagingQueueNotConfiguredError(
+            f"{PACKAGING_REQUEST_QUEUE_URL_ENV} is not configured; " "cannot enqueue packaging request"
+        )
+    return url
+
+
+def publish_packaging_request(
+    sqs_client: Any,
+    queue_url: str,
+    payload: Payload,
+) -> str:
+    """Send a packaging request to the FIFO queue keyed by entry_id.
+
+    Args:
+        sqs_client: boto3 SQS client.
+        queue_url: FIFO queue URL (must end in ``.fifo``).
+        payload: Parsed webhook payload.
+
+    Returns:
+        The SQS MessageId on success.
+
+    Raises:
+        Exception: Any error from ``send_message`` propagates so the webhook
+            can return 5xx and Benchling will retry.
+    """
+    entry_id = payload.entry_id  # raises ValueError if missing — let it propagate
+    body = json.dumps(payload.raw_payload)
+
+    response = sqs_client.send_message(
+        QueueUrl=queue_url,
+        MessageBody=body,
+        MessageGroupId=entry_id,
+        # ContentBasedDeduplication on the queue handles duplicate webhook
+        # deliveries within SQS's 5-min dedup window.
+    )
+    message_id = response.get("MessageId", "")
+
+    logger.info(
+        "Published packaging request",
+        entry_id=entry_id,
+        canvas_id=payload.canvas_id,
+        event_type=payload.event_type,
+        sqs_message_id=message_id,
+    )
+    return message_id

--- a/docker/src/sqs_consumer.py
+++ b/docker/src/sqs_consumer.py
@@ -82,21 +82,19 @@ def create_benchling_client(config: Config) -> Benchling:
     return Benchling(url=f"https://{secrets.tenant}.benchling.com", auth_method=auth_method)
 
 
-class SqsConsumer:
+class BaseSqsConsumer:
+    """Generic SQS polling/dispatch loop. Subclasses implement ``process_message``."""
+
     def __init__(
         self,
         *,
         queue_url: str,
-        config: Config,
-        benchling_factory: Callable[[], Benchling],
         sqs_client: Any,
         concurrency: int = 5,
         graceful_timeout: int = 30,
         stop_event: asyncio.Event | None = None,
     ):
         self.queue_url = queue_url
-        self.config = config
-        self.benchling_factory = benchling_factory
         self.sqs_client = sqs_client
         self.concurrency = concurrency
         self.graceful_timeout = graceful_timeout
@@ -123,6 +121,66 @@ class SqsConsumer:
             QueueUrl=self.queue_url,
             ReceiptHandle=receipt_handle,
         )
+
+    async def process_message(self, message: dict[str, Any]) -> None:
+        raise NotImplementedError
+
+    async def _run_task(self, message: dict[str, Any]) -> None:
+        try:
+            await self.process_message(message)
+        finally:
+            self.semaphore.release()
+
+    def _track_task(self, task: asyncio.Task[None]) -> None:
+        self.in_flight_tasks.add(task)
+        task.add_done_callback(self.in_flight_tasks.discard)
+
+    async def run(self) -> None:
+        while not self.stop_event.is_set():
+            messages = await self.receive_messages()
+            for message in messages:
+                if self.stop_event.is_set():
+                    break
+                await self.semaphore.acquire()
+                task = asyncio.create_task(self._run_task(message))
+                self._track_task(task)
+
+        if not self.in_flight_tasks:
+            return
+
+        _done, pending = await asyncio.wait(self.in_flight_tasks, timeout=self.graceful_timeout)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    def request_stop(self) -> None:
+        self.stop_event.set()
+
+
+class SqsConsumer(BaseSqsConsumer):
+    """Drains the package-revision EventBridge → SQS queue and refreshes canvases."""
+
+    def __init__(
+        self,
+        *,
+        queue_url: str,
+        config: Config,
+        benchling_factory: Callable[[], Benchling],
+        sqs_client: Any,
+        concurrency: int = 5,
+        graceful_timeout: int = 30,
+        stop_event: asyncio.Event | None = None,
+    ):
+        super().__init__(
+            queue_url=queue_url,
+            sqs_client=sqs_client,
+            concurrency=concurrency,
+            graceful_timeout=graceful_timeout,
+            stop_event=stop_event,
+        )
+        self.config = config
+        self.benchling_factory = benchling_factory
 
     async def process_message(self, message: dict[str, Any]) -> None:
         sqs_message_id = message.get("MessageId", "unknown")
@@ -201,38 +259,6 @@ class SqsConsumer:
                 duration_ms=int((time.monotonic() - start_time) * 1000),
                 outcome=outcome,
             )
-
-    async def _run_task(self, message: dict[str, Any]) -> None:
-        try:
-            await self.process_message(message)
-        finally:
-            self.semaphore.release()
-
-    def _track_task(self, task: asyncio.Task[None]) -> None:
-        self.in_flight_tasks.add(task)
-        task.add_done_callback(self.in_flight_tasks.discard)
-
-    async def run(self) -> None:
-        while not self.stop_event.is_set():
-            messages = await self.receive_messages()
-            for message in messages:
-                if self.stop_event.is_set():
-                    break
-                await self.semaphore.acquire()
-                task = asyncio.create_task(self._run_task(message))
-                self._track_task(task)
-
-        if not self.in_flight_tasks:
-            return
-
-        _done, pending = await asyncio.wait(self.in_flight_tasks, timeout=self.graceful_timeout)
-        for task in pending:
-            task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
-
-    def request_stop(self) -> None:
-        self.stop_event.set()
 
 
 def build_sqs_client(region: str) -> Any:

--- a/docker/src/sqs_consumer.py
+++ b/docker/src/sqs_consumer.py
@@ -14,6 +14,7 @@ from botocore.config import Config as BotocoreConfig
 
 from .config import Config, get_config
 from .package_event import RefreshOutcome, refresh_canvas_for_package_event
+from .secrets_manager import SecretsManagerError
 
 logger = structlog.get_logger(__name__)
 
@@ -23,6 +24,13 @@ DELETE_OUTCOMES = {
     RefreshOutcome.SKIPPED_NO_CANVAS.value,
     "skipped_filtered",
 }
+
+# Backoff bounds for the pre-start readiness wait when Benchling secrets are
+# not yet populated (e.g., fresh deploy where the config script has not run).
+# Starting at 30s keeps Secrets Manager churn low; capping at 300s bounds the
+# worst-case time-to-process after secrets finally appear.
+READY_WAIT_INITIAL_SECONDS = 30
+READY_WAIT_MAX_SECONDS = 300
 
 
 class PackageEventParseError(ValueError):
@@ -84,6 +92,7 @@ class SqsConsumer:
         sqs_client: Any,
         concurrency: int = 5,
         graceful_timeout: int = 30,
+        stop_event: asyncio.Event | None = None,
     ):
         self.queue_url = queue_url
         self.config = config
@@ -91,16 +100,20 @@ class SqsConsumer:
         self.sqs_client = sqs_client
         self.concurrency = concurrency
         self.graceful_timeout = graceful_timeout
-        self.stop_event = asyncio.Event()
+        self.stop_event = stop_event if stop_event is not None else asyncio.Event()
         self.semaphore = asyncio.Semaphore(concurrency)
         self.in_flight_tasks: set[asyncio.Task[None]] = set()
 
     async def receive_messages(self) -> list[dict[str, Any]]:
+        # Cap batch size to concurrency: with WaitTimeSeconds=20 and a bounded
+        # semaphore, asking for more than `concurrency` messages just makes the
+        # tail messages sit in the semaphore backlog eating visibility timeout.
+        batch_size = max(1, min(10, self.concurrency))
         response = await asyncio.to_thread(
             self.sqs_client.receive_message,
             QueueUrl=self.queue_url,
             WaitTimeSeconds=20,
-            MaxNumberOfMessages=10,
+            MaxNumberOfMessages=batch_size,
         )
         return response.get("Messages", [])
 
@@ -234,20 +247,87 @@ def build_sqs_client(region: str) -> Any:
     )
 
 
+async def _sleep_with_stop(stop_event: asyncio.Event, seconds: float) -> bool:
+    """Sleep up to ``seconds``, returning early if ``stop_event`` is set.
+
+    Returns ``True`` if the stop event fired during the sleep, ``False`` on timeout.
+    """
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=seconds)
+        return True
+    except asyncio.TimeoutError:
+        return False
+
+
+async def wait_for_ready_config(
+    stop_event: asyncio.Event,
+    *,
+    initial_backoff: float = READY_WAIT_INITIAL_SECONDS,
+    max_backoff: float = READY_WAIT_MAX_SECONDS,
+) -> Config | None:
+    """Block until Benchling secrets are populated and loadable.
+
+    The consumer has no useful work without valid secrets (it cannot filter
+    messages without ``s3_bucket_name`` / ``pkg_prefix``). Rather than crashing
+    and tripping the ECS deployment circuit breaker on a fresh deploy where
+    the secret is created empty by design, we loop here until the secret is
+    populated. The signal-driven ``stop_event`` lets ECS stop us cleanly.
+
+    Returns the ready ``Config``, or ``None`` if the stop event fired first.
+    """
+    attempt = 0
+    backoff = initial_backoff
+    while not stop_event.is_set():
+        try:
+            config = get_config()
+            secrets = config.get_benchling_secrets()
+            config.apply_benchling_secrets(secrets)
+        except (SecretsManagerError, ValueError) as exc:
+            attempt += 1
+            logger.warning(
+                "Benchling secrets not ready; SQS consumer waiting before retry",
+                attempt=attempt,
+                retry_in_seconds=backoff,
+                error=str(exc).split("\n", 1)[0],
+                error_type=type(exc).__name__,
+            )
+            if await _sleep_with_stop(stop_event, backoff):
+                return None
+            backoff = min(backoff * 2, max_backoff)
+            continue
+
+        logger.info(
+            "SQS consumer config loaded from secrets",
+            s3_bucket_name=config.s3_bucket_name,
+            pkg_prefix=config.pkg_prefix,
+            attempts=attempt + 1,
+        )
+        return config
+
+    return None
+
+
 async def main() -> int:
     queue_url = os.getenv("PACKAGE_EVENT_QUEUE_URL", "").strip()
     if not queue_url:
         logger.info("PACKAGE_EVENT_QUEUE_URL not configured; SQS consumer exiting")
         return 0
 
-    config = get_config()
-    secrets = config.get_benchling_secrets()
-    config.apply_benchling_secrets(secrets)
-    logger.info(
-        "SQS consumer config loaded from secrets",
-        s3_bucket_name=config.s3_bucket_name,
-        pkg_prefix=config.pkg_prefix,
-    )
+    # Install signal handlers up front so the container can be stopped cleanly
+    # even while we're waiting for secrets to become available.
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, stop_event.set)
+        except NotImplementedError:  # pragma: no cover - platform specific
+            signal.signal(sig, lambda _signum, _frame: stop_event.set())
+
+    config = await wait_for_ready_config(stop_event)
+    if config is None:
+        logger.info("SQS consumer stopped before Benchling secrets became available")
+        return 0
+
     sqs_client = build_sqs_client(config.aws_region)
     concurrency = int(os.getenv("PACKAGE_EVENT_CONCURRENCY", "5"))
     graceful_timeout = int(os.getenv("PACKAGE_EVENT_GRACEFUL_TIMEOUT", "30"))
@@ -259,14 +339,8 @@ async def main() -> int:
         sqs_client=sqs_client,
         concurrency=concurrency,
         graceful_timeout=graceful_timeout,
+        stop_event=stop_event,
     )
-
-    loop = asyncio.get_running_loop()
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        try:
-            loop.add_signal_handler(sig, consumer.request_stop)
-        except NotImplementedError:  # pragma: no cover - platform specific
-            signal.signal(sig, lambda _signum, _frame: consumer.request_stop())
 
     await consumer.run()
     return 0

--- a/docker/tests/conftest.py
+++ b/docker/tests/conftest.py
@@ -33,5 +33,14 @@ def isolate_environment(monkeypatch):
     for var in env_vars_to_clear:
         monkeypatch.delenv(var, raising=False)
 
+    # Default packaging-request queue URL so create_app() doesn't enter
+    # degraded mode in tests that don't explicitly need to exercise the
+    # missing-queue branch. Tests that need to remove it can call
+    # monkeypatch.delenv("PACKAGING_REQUEST_QUEUE_URL").
+    monkeypatch.setenv(
+        "PACKAGING_REQUEST_QUEUE_URL",
+        "https://sqs.us-west-2.amazonaws.com/123/test.fifo",
+    )
+
     # Yield to run the test
     yield

--- a/docker/tests/test_app.py
+++ b/docker/tests/test_app.py
@@ -39,9 +39,16 @@ class TestFastAPIApp:
 
     @pytest.fixture
     def mock_entry_packager(self):
-        """Mock EntryPackager."""
+        """Mock EntryPackager (with the sqs_client the publisher needs)."""
         packager = Mock()
+        packager.sqs_client = Mock()
         return packager
+
+    @pytest.fixture
+    def mock_publish(self):
+        """Patch the FIFO publisher; webhook handlers enqueue here."""
+        with patch("src.app.publish_packaging_request", return_value="msg-id-test") as publish:
+            yield publish
 
     @pytest.fixture
     def app(
@@ -49,7 +56,14 @@ class TestFastAPIApp:
         mock_config,
         mock_benchling_client,
         mock_entry_packager,
+        mock_publish,
+        monkeypatch,
     ):
+        # Webhook handlers require this env var to enqueue work.
+        monkeypatch.setenv(
+            "PACKAGING_REQUEST_QUEUE_URL",
+            "https://sqs.us-west-2.amazonaws.com/123/test.fifo",
+        )
         with (
             patch("src.app.get_config", return_value=mock_config),
             patch("src.app.Benchling", return_value=mock_benchling_client),
@@ -91,10 +105,8 @@ class TestFastAPIApp:
             with pytest.raises(Exception):
                 create_app()
 
-    def test_webhook_endpoint_success(self, client, mock_entry_packager):
-        """Test webhook endpoint with valid payload."""
-        mock_entry_packager.execute_workflow_async.return_value = "etr_123456"
-
+    def test_webhook_endpoint_success(self, client, mock_publish):
+        """Test webhook endpoint enqueues a packaging request."""
         payload = {
             "channel": "events",
             "message": {"type": "v2.entry.updated.fields", "resourceId": "etr_123456"},
@@ -106,6 +118,7 @@ class TestFastAPIApp:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ACCEPTED"
+        mock_publish.assert_called_once()
 
     def test_webhook_endpoint_no_payload(self, client):
         """Test webhook endpoint with no JSON payload."""
@@ -131,10 +144,8 @@ class TestFastAPIApp:
         assert "error" in data
         assert "not found" in data["error"].lower()
 
-    def test_canvas_endpoint_starts_workflow(self, client, mock_entry_packager):
-        """Test /canvas endpoint returns 202 and starts workflow."""
-        mock_entry_packager.execute_workflow_async.return_value = "etr_123456"
-
+    def test_canvas_endpoint_starts_workflow(self, client, mock_publish):
+        """Test /canvas endpoint returns 202 and enqueues a packaging request."""
         payload = {
             "channel": "events",
             "message": {"type": "v2.canvas.initialized", "resourceId": "etr_123456"},
@@ -148,8 +159,10 @@ class TestFastAPIApp:
         data = response.json()
         assert data["status"] == "ACCEPTED"
 
-        workflow_payload = mock_entry_packager.execute_workflow_async.call_args.args[0]
-        assert workflow_payload.canvas_id == "canvas_123"
+        # publish_packaging_request(sqs_client, queue_url, payload)
+        mock_publish.assert_called_once()
+        published_payload = mock_publish.call_args.args[2]
+        assert published_payload.canvas_id == "canvas_123"
 
     @pytest.mark.local
     def test_canvas_endpoint_handles_browse_files_button(self, client, mock_benchling_client):

--- a/docker/tests/test_canvas_updating_blocks.py
+++ b/docker/tests/test_canvas_updating_blocks.py
@@ -1,0 +1,196 @@
+"""Test the initial 'Updating...' canvas state.
+
+The initial canvas shown to the user (before the background workflow runs)
+should have the SAME layout as the final canvas — main nav buttons, a primary
+package header, and the footer — but with an 'Updating...' status instead of
+an 'Updated at' timestamp. Linked-package lookups are skipped so this stays
+fast enough to run on the request thread.
+
+These tests also print the generated blocks (as dicts) to stdout so the UX
+can be eyeballed without a live Benchling canvas. Run with ``-s`` to see output:
+
+    pytest docker/tests/test_canvas_updating_blocks.py -s
+"""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from benchling_api_client.v2.stable.models.markdown_ui_block_update import MarkdownUiBlockUpdate
+from benchling_api_client.v2.stable.models.section_ui_block_update import SectionUiBlockUpdate
+
+from src.canvas import CanvasManager
+from src.canvas_blocks import blocks_to_dict
+from src.canvas_formatting import format_canvas_footer
+from src.config import Config
+from src.payload import Payload
+
+
+@pytest.fixture
+def mock_config():
+    config = Mock(spec=Config)
+    config.s3_bucket_name = "test-bucket"
+    config.s3_prefix = "benchling"
+    config.quilt_catalog = "test.quiltdata.com"
+    config.quilt_database = "test-athena-db"
+    config.package_key = "experiment_id"
+    config.athena_user_workgroup = "test-workgroup"
+    config.aws_region = "us-east-1"
+    config.quilt_write_role_arn = None
+    return config
+
+
+@pytest.fixture
+def mock_payload():
+    payload = Mock(spec=Payload)
+    payload.entry_id = "etr_test123"
+    payload.canvas_id = "cnvs_test456"
+    payload.display_id = "EXP25000088"
+    payload.package_name.return_value = "benchling/EXP25000088"
+    payload.set_display_id = Mock()
+    return payload
+
+
+@pytest.fixture
+def mock_benchling():
+    mock = Mock()
+    mock_entry = Mock()
+    mock_entry.id = "etr_test123"
+    mock_entry.display_id = "EXP25000088"
+    mock.entries.get_entry_by_id.return_value = mock_entry
+    return mock
+
+
+@pytest.fixture
+def canvas_manager(mock_benchling, mock_config, mock_payload):
+    return CanvasManager(benchling=mock_benchling, config=mock_config, payload=mock_payload)
+
+
+def _dump_blocks(label: str, block_dicts: list) -> None:
+    """Pretty-print a set of blocks so the UX can be eyeballed."""
+    print(f"\n================ {label} ================")
+    print(json.dumps(block_dicts, indent=2, default=str))
+    print("=" * (len(label) + 34))
+
+
+class TestUpdatingCanvasBlocks:
+    """The initial canvas uses the same layout as the final view, with an 'Updating...' footer."""
+
+    def test_footer_shows_updating_when_flag_set(self):
+        footer = format_canvas_footer(
+            version="0.17.1",
+            quilt_host="test.com",
+            bucket="test-bucket",
+            is_updating=True,
+        )
+        assert "Updating..." in footer
+        assert "Updated at" not in footer
+        assert "Pending update" not in footer
+
+    def test_footer_updating_overrides_updated_at(self):
+        """If both are set, 'Updating...' wins — this is an in-progress state."""
+        footer = format_canvas_footer(
+            version="0.17.1",
+            quilt_host="test.com",
+            bucket="test-bucket",
+            updated_at="2026-04-15 12:00 UTC",
+            is_updating=True,
+        )
+        assert "Updating..." in footer
+        assert "Updated at" not in footer
+
+    def test_update_button_disabled_while_updating(self, canvas_manager):
+        """During the 'Updating...' phase, the Update Package button must be
+        disabled so a second click cannot spawn a concurrent export workflow.
+        Browse Package stays enabled — on a re-export the previous package
+        version is still valid."""
+        updating = canvas_manager._make_blocks(is_updating=True)
+
+        # The first block is the main-nav section with two buttons: [Browse, Update]
+        nav_section = updating[0]
+        browse_btn, update_btn = nav_section.children
+
+        assert browse_btn.text == "Browse Package"
+        assert browse_btn.enabled is True, "Browse stays enabled during updating"
+
+        assert update_btn.text == "Update Package"
+        assert update_btn.enabled is False, "Update is disabled during updating"
+
+    def test_update_button_reenabled_on_final_canvas(self, canvas_manager):
+        """When the background workflow delivers the real update, both buttons
+        must be re-enabled."""
+        canvas_manager._linked_packages = []
+        canvas_manager._errors = []
+        canvas_manager._package_query = Mock()
+        canvas_manager._package_query.find_unique_packages.return_value = {"packages": []}
+
+        final = canvas_manager._make_blocks(updated_at="2026-04-15 12:00 UTC")
+        browse_btn, update_btn = final[0].children
+
+        assert browse_btn.enabled is True
+        assert update_btn.enabled is True, "Update is re-enabled once updated_at is set"
+
+    def test_updating_blocks_match_regular_layout(self, canvas_manager):
+        """The 'Updating...' canvas has the same block types in the same order
+        as the final canvas: main-nav section → package header markdown → footer markdown.
+        """
+        updating = canvas_manager._make_blocks(is_updating=True)
+
+        # Reset linked_packages cache so the "final" view is comparable
+        canvas_manager._linked_packages = []
+        canvas_manager._errors = []
+
+        # Types in order
+        assert isinstance(updating[0], SectionUiBlockUpdate), "first block is the main-nav button section"
+        assert isinstance(updating[1], MarkdownUiBlockUpdate), "second block is the package header"
+        assert updating[1].id == "md1"
+        assert isinstance(updating[-1], MarkdownUiBlockUpdate), "last block is the footer"
+        assert updating[-1].id == "md-footer"
+
+        # Footer shows the Updating state
+        assert "Updating..." in updating[-1].value
+        assert "Updated at" not in updating[-1].value
+
+        # Package header includes the display id and package name
+        assert "EXP25000088" in updating[1].value
+        assert "benchling/EXP25000088" in updating[1].value
+
+    def test_updating_blocks_skip_linked_packages_query(self, canvas_manager):
+        """The initial update must NOT run the Athena linked-packages query —
+        that's slow and the data will be refreshed by the background workflow."""
+        # If the query were run, this mock would be hit. It isn't injected, so the
+        # test would blow up on the real PackageQuery construction. Instead we
+        # assert that the method does not touch _package_query at all.
+        canvas_manager._package_query = Mock()
+        canvas_manager._package_query.find_unique_packages.side_effect = AssertionError(
+            "find_unique_packages must not be called during an 'Updating...' render"
+        )
+
+        # Should not raise
+        canvas_manager._make_blocks(is_updating=True)
+        canvas_manager._package_query.find_unique_packages.assert_not_called()
+
+    def test_print_updating_blocks_for_visual_review(self, canvas_manager, capsys):
+        """Print the generated blocks so the user can eyeball the UX without
+        a live Benchling canvas. Run with ``pytest -s`` to see the output."""
+        updating_blocks = canvas_manager._make_blocks(is_updating=True)
+        updating_dicts = blocks_to_dict(updating_blocks)
+
+        _dump_blocks("INITIAL 'Updating...' CANVAS", updating_dicts)
+
+        # Also render a simulated "final" canvas for side-by-side comparison
+        canvas_manager._linked_packages = []
+        canvas_manager._errors = []
+        canvas_manager._package_query = Mock()
+        canvas_manager._package_query.find_unique_packages.return_value = {"packages": []}
+
+        final_blocks = canvas_manager._make_blocks(updated_at="2026-04-15 12:00 UTC")
+        final_dicts = blocks_to_dict(final_blocks)
+        _dump_blocks("FINAL 'Updated at ...' CANVAS", final_dicts)
+
+        # Sanity: capsys is available so the test framework actually captured output
+        captured = capsys.readouterr()
+        assert "INITIAL 'Updating...' CANVAS" in captured.out
+        assert "FINAL 'Updated at ...' CANVAS" in captured.out
+        assert "Updating..." in captured.out
+        assert "Updated at 2026-04-15 12:00 UTC" in captured.out

--- a/docker/tests/test_entry_packager.py
+++ b/docker/tests/test_entry_packager.py
@@ -446,6 +446,16 @@ class TestEntryPackager:
                 )
 
     # Episode 6: SendToSQS tests
+    @staticmethod
+    def _payload_with(
+        event_type: str = "v2.entry.created",
+        timestamp: str | None = "2025-10-02T10:00:00Z",
+    ) -> Payload:
+        message: dict = {"id": "evt_1", "resourceId": "etr_456", "type": event_type}
+        if timestamp is not None:
+            message["timestamp"] = timestamp
+        return Payload({"message": message, "baseURL": "https://demo.benchling.com"})
+
     def test_send_to_sqs_success(self, orchestrator):
         """Test successful SQS message send."""
         mock_response = {"MessageId": "msg_123"}
@@ -453,10 +463,39 @@ class TestEntryPackager:
         with patch.object(orchestrator.sqs_client, "send_message", return_value=mock_response):
             result = orchestrator._send_to_sqs(
                 package_name="benchling/EXP0001",  # Now uses display_id
-                timestamp="2025-10-02T10:00:00Z",
+                payload=self._payload_with(),
             )
 
         assert result["MessageId"] == "msg_123"
+
+    def test_send_to_sqs_commit_message_includes_event_type_and_timestamp(self, orchestrator):
+        """Commit message embeds the event type so revisions are self-describing."""
+        mock_response = {"MessageId": "msg_123"}
+
+        with patch.object(orchestrator.sqs_client, "send_message", return_value=mock_response) as send_mock:
+            orchestrator._send_to_sqs(
+                package_name="benchling/EXP0001",
+                payload=self._payload_with(
+                    event_type="v2.entry.updated.reviewRecord",
+                    timestamp="2026-04-15T14:25:03Z",
+                ),
+            )
+
+        message_body = json.loads(send_mock.call_args.kwargs["MessageBody"])
+        assert message_body["commit_message"] == ("Benchling v2.entry.updated.reviewRecord at 2026-04-15T14:25:03Z")
+
+    def test_send_to_sqs_commit_message_drops_timestamp_when_missing(self, orchestrator):
+        """Missing timestamp must not produce a trailing ' at ' suffix."""
+        mock_response = {"MessageId": "msg_123"}
+
+        with patch.object(orchestrator.sqs_client, "send_message", return_value=mock_response) as send_mock:
+            orchestrator._send_to_sqs(
+                package_name="benchling/EXP0001",
+                payload=self._payload_with(event_type="v2.entry.created", timestamp=None),
+            )
+
+        message_body = json.loads(send_mock.call_args.kwargs["MessageBody"])
+        assert message_body["commit_message"] == "Benchling v2.entry.created"
 
     def test_send_to_sqs_includes_workflow_when_configured(self, orchestrator):
         """Test workflow is forwarded to the Quilt package creation payload."""
@@ -466,7 +505,7 @@ class TestEntryPackager:
         with patch.object(orchestrator.sqs_client, "send_message", return_value=mock_response) as send_mock:
             orchestrator._send_to_sqs(
                 package_name="benchling/EXP0001",
-                timestamp="2025-10-02T10:00:00Z",
+                payload=self._payload_with(),
             )
 
         message_body = json.loads(send_mock.call_args.kwargs["MessageBody"])
@@ -480,7 +519,7 @@ class TestEntryPackager:
         with patch.object(orchestrator.sqs_client, "send_message", return_value=mock_response) as send_mock:
             orchestrator._send_to_sqs(
                 package_name="benchling/EXP0001",
-                timestamp="2025-10-02T10:00:00Z",
+                payload=self._payload_with(),
             )
 
         message_body = json.loads(send_mock.call_args.kwargs["MessageBody"])
@@ -679,12 +718,11 @@ class TestEntryPackager:
 
         s3_client = Mock()
 
-        # Mock get_object to return the sidecar file for .canvas_id reads,
-        # and entry.json for fallback reads.
+        # Entry events read canvas_id from any existing entry.json. FIFO
+        # sequencing on entry_id guarantees the prior canvas-event write is
+        # visible before this entry-event workflow runs.
         def mock_get_object(**kwargs):
             key = kwargs.get("Key", "")
-            if key.endswith("/.canvas_id"):
-                return {"Body": io.BytesIO(b"canvas_preserved")}
             if key.endswith("/entry.json"):
                 return {"Body": io.BytesIO(json.dumps({"canvas_id": "canvas_preserved"}).encode("utf-8"))}
             raise s3_client.exceptions.NoSuchKey({"Error": {"Code": "NoSuchKey"}}, "GetObject")
@@ -722,56 +760,3 @@ class TestEntryPackager:
 
         assert written_entry_json is not None
         assert written_entry_json["canvas_id"] == "canvas_preserved"
-
-    # Episode 9: Async execution tests
-    def test_execute_workflow_async(self, orchestrator, mock_benchling):
-        """Test async workflow execution returns immediately."""
-        # Mock SDK calls
-        mock_entry = Mock()
-        mock_entry.to_dict.return_value = {
-            "id": "etr_123",
-            "display_id": "EXP0001",
-            "fields": [],
-        }
-        mock_benchling.entries.get_entry_by_id.return_value = mock_entry
-
-        mock_export_result = Mock()
-        mock_export_result.task_id = "task_123"
-        mock_benchling.exports.export.return_value = mock_export_result
-
-        mock_task = Mock()
-        mock_task.id = "task_123"
-        mock_task.status = Mock()
-        mock_task.status.value = "SUCCEEDED"
-        mock_task.response = Mock()
-        mock_task.response.get = Mock(return_value="https://example.com/export.zip")
-        mock_benchling.tasks.get_by_id.return_value = mock_task
-
-        # Mock _process_export (inline processing)
-        mock_process_result = {
-            "statusCode": 200,
-            "package_name": "benchling/EXP0001",  # Now uses display_id
-            "files_uploaded": [],
-            "total_files": 5,
-        }
-        mock_sqs_response = {"MessageId": "msg_123"}
-
-        with (
-            patch.object(orchestrator, "_process_export", return_value=mock_process_result),
-            patch.object(orchestrator.sqs_client, "send_message", return_value=mock_sqs_response),
-        ):
-            payload = Payload(
-                {
-                    "message": {
-                        "id": "evt_456",
-                        "resourceId": "etr_123",
-                        "timestamp": "2025-10-02T10:00:00Z",
-                    },
-                    "baseURL": "https://demo.benchling.com",
-                }
-            )
-
-            # Should return immediately with entry_id
-            entry_id = orchestrator.execute_workflow_async(payload)
-
-            assert entry_id == "etr_123"

--- a/docker/tests/test_flexible_routes.py
+++ b/docker/tests/test_flexible_routes.py
@@ -49,14 +49,24 @@ class TestFlexibleRoutes:
 
     @pytest.fixture
     def mock_entry_packager(self):
-        """Mock EntryPackager."""
+        """Mock EntryPackager (with the sqs_client the publisher needs)."""
         packager = Mock()
-        packager.execute_workflow_async.return_value = "etr_123456"
+        packager.sqs_client = Mock()
         return packager
 
     @pytest.fixture
-    def app(self, mock_config, mock_benchling_client, mock_entry_packager):
+    def mock_publish(self):
+        """Patch the FIFO publisher; webhook handlers enqueue here."""
+        with patch("src.app.publish_packaging_request", return_value="msg-id-test") as publish:
+            yield publish
+
+    @pytest.fixture
+    def app(self, mock_config, mock_benchling_client, mock_entry_packager, mock_publish, monkeypatch):
         """Create FastAPI app with mocked dependencies."""
+        monkeypatch.setenv(
+            "PACKAGING_REQUEST_QUEUE_URL",
+            "https://sqs.us-west-2.amazonaws.com/123/test.fifo",
+        )
         with (
             patch("src.app.get_config", return_value=mock_config),
             patch("src.app.Benchling", return_value=mock_benchling_client),
@@ -127,7 +137,7 @@ class TestFlexibleRoutes:
     # ============================================================================
 
     @pytest.mark.parametrize("stage", ["prod", "dev", "staging"])
-    def test_event_webhook_with_stage_prefix(self, client, mock_entry_packager, stage):
+    def test_event_webhook_with_stage_prefix(self, client, mock_publish, stage):
         """Test /event webhook with stage prefix (API Gateway path)."""
         payload = {
             "channel": "events",
@@ -140,7 +150,7 @@ class TestFlexibleRoutes:
         data = response.json()
         assert data["status"] == "ACCEPTED"
         assert "entry_id" in data
-        mock_entry_packager.execute_workflow_async.assert_called_once()
+        mock_publish.assert_called_once()
 
     def test_event_webhook_direct_path(self, client, mock_entry_packager):
         """Test /event webhook without stage prefix (direct call)."""
@@ -235,7 +245,7 @@ class TestFlexibleRoutes:
         assert direct_response.status_code == stage_response.status_code
         assert direct_response.json() == stage_response.json()
 
-    def test_event_responses_are_identical(self, client, mock_entry_packager):
+    def test_event_responses_are_identical(self, client, mock_publish):
         """Verify direct and stage-prefixed event endpoints return identical responses."""
         payload = {
             "channel": "events",
@@ -247,8 +257,8 @@ class TestFlexibleRoutes:
         stage_response = client.post("/prod/event", json=payload)
 
         assert direct_response.status_code == stage_response.status_code
-        # Both should have called the packager
-        assert mock_entry_packager.execute_workflow_async.call_count == 2
+        # Both should have enqueued a packaging request
+        assert mock_publish.call_count == 2
 
     # ============================================================================
     # Verify HMAC verification works for both path styles

--- a/docker/tests/test_packaging_consumer.py
+++ b/docker/tests/test_packaging_consumer.py
@@ -1,0 +1,122 @@
+"""Tests for the FIFO packaging-request consumer."""
+
+import json
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.packaging_consumer import PackagingConsumer
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _packaging_consumer(entry_packager: Mock) -> tuple[PackagingConsumer, AsyncMock]:
+    sqs_client = Mock()
+    consumer = PackagingConsumer(
+        queue_url="https://sqs.us-west-2.amazonaws.com/123/test.fifo",
+        sqs_client=sqs_client,
+        entry_packager=entry_packager,
+    )
+    delete_mock = AsyncMock()
+    consumer.delete_message = delete_mock  # type: ignore[method-assign]
+    return consumer, delete_mock
+
+
+def _message(body: dict, *, message_group_id: str = "etr_abc") -> dict:
+    return {
+        "MessageId": f"msg-{message_group_id}",
+        "ReceiptHandle": f"rh-{message_group_id}",
+        "Attributes": {"MessageGroupId": message_group_id},
+        "Body": json.dumps(body),
+    }
+
+
+@pytest.mark.anyio
+async def test_consumer_runs_workflow_and_deletes_on_success():
+    entry_packager = Mock()
+    entry_packager.benchling = Mock()
+    entry_packager.execute_workflow = Mock(return_value={"status": "SUCCESS"})
+
+    consumer, delete_mock = _packaging_consumer(entry_packager)
+
+    body = {"message": {"type": "v2.entry.created", "resourceId": "etr_abc"}}
+    await consumer.process_message(_message(body))
+
+    entry_packager.execute_workflow.assert_called_once()
+    payload_arg = entry_packager.execute_workflow.call_args.args[0]
+    assert payload_arg.entry_id == "etr_abc"
+    delete_mock.assert_awaited_once_with("rh-etr_abc")
+
+
+@pytest.mark.anyio
+async def test_consumer_retains_message_on_workflow_error():
+    entry_packager = Mock()
+    entry_packager.benchling = Mock()
+    entry_packager.execute_workflow = Mock(side_effect=RuntimeError("boom"))
+
+    consumer, delete_mock = _packaging_consumer(entry_packager)
+
+    body = {"message": {"type": "v2.entry.created", "resourceId": "etr_abc"}}
+    await consumer.process_message(_message(body))
+
+    delete_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_consumer_deletes_unparseable_messages():
+    """A malformed body in a FIFO group blocks the entire group; delete it."""
+    entry_packager = Mock()
+    entry_packager.benchling = Mock()
+    entry_packager.execute_workflow = Mock()
+
+    consumer, delete_mock = _packaging_consumer(entry_packager)
+
+    bad_message = {
+        "MessageId": "msg-bad",
+        "ReceiptHandle": "rh-bad",
+        "Attributes": {"MessageGroupId": "etr_abc"},
+        "Body": "not-json",
+    }
+    await consumer.process_message(bad_message)
+
+    entry_packager.execute_workflow.assert_not_called()
+    delete_mock.assert_awaited_once_with("rh-bad")
+
+
+@pytest.mark.anyio
+async def test_consumer_dispatches_messages_in_arrival_order():
+    """Sequential dispatch is what eliminates the canvas_id race; SQS FIFO
+    ordering is the AWS-side guarantee, the consumer just calls
+    process_message for each message it receives.
+    """
+    entry_packager = Mock()
+    entry_packager.benchling = Mock()
+    seen: list[str] = []
+
+    def record(payload):
+        seen.append(payload.event_type)
+        return {"status": "SUCCESS"}
+
+    entry_packager.execute_workflow = record
+
+    consumer, _delete_mock = _packaging_consumer(entry_packager)
+
+    entry_msg = _message({"message": {"type": "v2.entry.created", "id": "1", "resourceId": "etr_abc"}})
+    canvas_msg = _message(
+        {
+            "message": {
+                "type": "v2.canvas.created",
+                "id": "2",
+                "resourceId": "etr_abc",
+                "canvasId": "cnvs_x",
+            }
+        }
+    )
+
+    await consumer.process_message(entry_msg)
+    await consumer.process_message(canvas_msg)
+
+    assert seen == ["v2.entry.created", "v2.canvas.created"]

--- a/docker/tests/test_packaging_publisher.py
+++ b/docker/tests/test_packaging_publisher.py
@@ -1,0 +1,108 @@
+"""Tests for the FIFO packaging-request publisher."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from src.packaging_publisher import (
+    PackagingQueueNotConfiguredError,
+    get_packaging_queue_url,
+    publish_packaging_request,
+)
+from src.payload import Payload
+
+
+@pytest.fixture
+def queue_url():
+    return "https://sqs.us-west-2.amazonaws.com/123456789012/packaging.fifo"
+
+
+@pytest.fixture
+def entry_payload():
+    return Payload(
+        {
+            "message": {
+                "type": "v2.entry.created",
+                "id": "evt_1",
+                "resourceId": "etr_abc",
+                "timestamp": "2026-04-15T10:00:00Z",
+            },
+            "baseURL": "https://demo.benchling.com",
+        }
+    )
+
+
+@pytest.fixture
+def canvas_payload():
+    return Payload(
+        {
+            "message": {
+                "type": "v2.canvas.created",
+                "id": "evt_2",
+                "resourceId": "etr_abc",
+                "canvasId": "cnvs_xyz",
+                "timestamp": "2026-04-15T10:00:01Z",
+            },
+            "baseURL": "https://demo.benchling.com",
+        }
+    )
+
+
+def test_publish_uses_entry_id_as_message_group_id(queue_url, entry_payload):
+    """All work for a single entry must serialize via MessageGroupId=entry_id."""
+    sqs_client = Mock()
+    sqs_client.send_message.return_value = {"MessageId": "msg-1"}
+
+    publish_packaging_request(sqs_client, queue_url, entry_payload)
+
+    kwargs = sqs_client.send_message.call_args.kwargs
+    assert kwargs["QueueUrl"] == queue_url
+    assert kwargs["MessageGroupId"] == "etr_abc"
+
+
+def test_publish_canvas_event_groups_with_matching_entry(queue_url, entry_payload, canvas_payload):
+    """A canvas event for the same entry must land in the same MessageGroup."""
+    sqs_client = Mock()
+    sqs_client.send_message.return_value = {"MessageId": "x"}
+
+    publish_packaging_request(sqs_client, queue_url, entry_payload)
+    publish_packaging_request(sqs_client, queue_url, canvas_payload)
+
+    group_ids = [c.kwargs["MessageGroupId"] for c in sqs_client.send_message.call_args_list]
+    assert group_ids == ["etr_abc", "etr_abc"]
+
+
+def test_publish_body_round_trips_through_payload(queue_url, canvas_payload):
+    """The serialized body must reconstruct an equivalent Payload on the consumer."""
+    sqs_client = Mock()
+    sqs_client.send_message.return_value = {"MessageId": "x"}
+
+    publish_packaging_request(sqs_client, queue_url, canvas_payload)
+
+    body = sqs_client.send_message.call_args.kwargs["MessageBody"]
+    rebuilt = Payload(json.loads(body))
+
+    assert rebuilt.entry_id == canvas_payload.entry_id
+    assert rebuilt.canvas_id == canvas_payload.canvas_id
+    assert rebuilt.event_type == canvas_payload.event_type
+
+
+def test_publish_returns_message_id(queue_url, entry_payload):
+    sqs_client = Mock()
+    sqs_client.send_message.return_value = {"MessageId": "msg-42"}
+
+    result = publish_packaging_request(sqs_client, queue_url, entry_payload)
+
+    assert result == "msg-42"
+
+
+def test_get_packaging_queue_url_raises_when_unset(monkeypatch):
+    monkeypatch.delenv("PACKAGING_REQUEST_QUEUE_URL", raising=False)
+    with pytest.raises(PackagingQueueNotConfiguredError):
+        get_packaging_queue_url()
+
+
+def test_get_packaging_queue_url_returns_value(monkeypatch):
+    monkeypatch.setenv("PACKAGING_REQUEST_QUEUE_URL", "https://sqs/x.fifo")
+    assert get_packaging_queue_url() == "https://sqs/x.fifo"

--- a/docker/tests/test_sqs_consumer.py
+++ b/docker/tests/test_sqs_consumer.py
@@ -1,9 +1,17 @@
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from src.package_event import RefreshOutcome, RefreshResult
-from src.sqs_consumer import PackageEventParseError, SqsConsumer, main, parse_package_event_message
+from src.secrets_manager import SecretsManagerError
+from src.sqs_consumer import (
+    PackageEventParseError,
+    SqsConsumer,
+    main,
+    parse_package_event_message,
+    wait_for_ready_config,
+)
 
 
 @pytest.fixture
@@ -161,3 +169,141 @@ async def test_main_applies_secrets_before_polling():
 
     mock_config.get_benchling_secrets.assert_called_once()
     mock_config.apply_benchling_secrets.assert_called_once_with(mock_secrets)
+
+
+@pytest.mark.anyio
+async def test_wait_for_ready_config_retries_until_secret_populated():
+    """Fresh-deploy case: BenchlingSecret is created empty, then the config
+    script populates it. The consumer must keep retrying rather than crashing.
+
+    This is the root cause of the ECS Deployment Circuit Breaker failure the
+    reviewer flagged on quiltdata/deployment#2357.
+    """
+    mock_config = Mock()
+    mock_config.s3_bucket_name = "quilt-bake"
+    mock_config.pkg_prefix = "benchling"
+    mock_config.get_benchling_secrets.side_effect = [
+        SecretsManagerError("Missing required parameters in secret"),
+        SecretsManagerError("Missing required parameters in secret"),
+        Mock(user_bucket="quilt-bake"),  # third attempt succeeds
+    ]
+
+    stop_event = asyncio.Event()
+
+    with patch("src.sqs_consumer.get_config", return_value=mock_config):
+        # initial_backoff=0 keeps the test fast; the behavior under test is
+        # retry-until-success, not the wall-clock schedule.
+        result = await wait_for_ready_config(stop_event, initial_backoff=0, max_backoff=0)
+
+    assert result is mock_config
+    assert mock_config.get_benchling_secrets.call_count == 3
+    mock_config.apply_benchling_secrets.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_wait_for_ready_config_retries_on_missing_env_var():
+    """get_config() raises ValueError when BenchlingSecret env var is empty.
+
+    The retry loop must treat this the same as a SecretsManagerError so a
+    mis-ordered deploy (e.g., env var populated slightly after container start)
+    does not crash-loop.
+    """
+    mock_config = Mock()
+    mock_config.s3_bucket_name = "quilt-bake"
+    mock_config.pkg_prefix = "benchling"
+    mock_config.get_benchling_secrets.return_value = Mock(user_bucket="quilt-bake")
+
+    attempts = {"count": 0}
+
+    def fake_get_config():
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise ValueError("Missing required environment variable: BenchlingSecret")
+        return mock_config
+
+    stop_event = asyncio.Event()
+
+    with patch("src.sqs_consumer.get_config", side_effect=fake_get_config):
+        result = await wait_for_ready_config(stop_event, initial_backoff=0, max_backoff=0)
+
+    assert result is mock_config
+    assert attempts["count"] == 2
+
+
+@pytest.mark.anyio
+async def test_wait_for_ready_config_short_circuits_on_stop():
+    """SIGTERM during the readiness wait must exit the loop cleanly."""
+    mock_config = Mock()
+    mock_config.get_benchling_secrets.side_effect = SecretsManagerError("Secret is empty")
+
+    stop_event = asyncio.Event()
+    stop_event.set()  # simulate SIGTERM already delivered
+
+    with patch("src.sqs_consumer.get_config", return_value=mock_config):
+        result = await wait_for_ready_config(stop_event, initial_backoff=0, max_backoff=0)
+
+    assert result is None
+    # With stop_event pre-set, we should not even attempt a fetch.
+    mock_config.get_benchling_secrets.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_main_exits_cleanly_when_stopped_during_wait():
+    """End-to-end: main() must not invoke the consumer run loop if stopped
+    before secrets become available."""
+    mock_config = Mock()
+    mock_config.get_benchling_secrets.side_effect = SecretsManagerError("Secret is empty")
+
+    async def fake_wait_for_ready_config(stop_event, **_kwargs):
+        return None  # simulate stop arriving before secrets populated
+
+    with (
+        patch.dict("os.environ", {"PACKAGE_EVENT_QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/123/test"}),
+        patch("src.sqs_consumer.wait_for_ready_config", side_effect=fake_wait_for_ready_config),
+        patch("src.sqs_consumer.build_sqs_client") as build_client,
+        patch("src.sqs_consumer.SqsConsumer.run", new_callable=AsyncMock) as run,
+    ):
+        rc = await main()
+
+    assert rc == 0
+    build_client.assert_not_called()
+    run.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_receive_messages_caps_batch_size_to_concurrency(mock_config):
+    """MaxNumberOfMessages should match concurrency so batched messages don't
+    pile up in the semaphore backlog eating visibility timeout."""
+    sqs_client = Mock()
+    sqs_client.receive_message.return_value = {"Messages": []}
+    consumer = SqsConsumer(
+        queue_url="https://sqs.us-west-2.amazonaws.com/123456789012/test",
+        config=mock_config,
+        benchling_factory=Mock(),
+        sqs_client=sqs_client,
+        concurrency=3,
+    )
+
+    await consumer.receive_messages()
+
+    kwargs = sqs_client.receive_message.call_args.kwargs
+    assert kwargs["MaxNumberOfMessages"] == 3
+
+
+@pytest.mark.anyio
+async def test_receive_messages_batch_size_capped_at_ten(mock_config):
+    """SQS caps MaxNumberOfMessages at 10 regardless of our concurrency."""
+    sqs_client = Mock()
+    sqs_client.receive_message.return_value = {"Messages": []}
+    consumer = SqsConsumer(
+        queue_url="https://sqs.us-west-2.amazonaws.com/123456789012/test",
+        config=mock_config,
+        benchling_factory=Mock(),
+        sqs_client=sqs_client,
+        concurrency=25,
+    )
+
+    await consumer.receive_messages()
+
+    kwargs = sqs_client.receive_message.call_args.kwargs
+    assert kwargs["MaxNumberOfMessages"] == 10

--- a/docker/uv.lock
+++ b/docker/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "benchling-quilt-integration"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "benchling-sdk" },

--- a/docker/uv.lock
+++ b/docker/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "benchling-quilt-integration"
-version = "0.17.1"
+version = "0.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "benchling-sdk" },

--- a/lib/benchling-webhook-stack.ts
+++ b/lib/benchling-webhook-stack.ts
@@ -283,6 +283,26 @@ export class BenchlingWebhookStack extends cdk.Stack {
             },
         });
 
+        // FIFO queue that serializes packaging work per entry_id. Replaces the
+        // old daemon-thread fire-and-forget in execute_workflow_async, removing
+        // the canvas_id race that the .canvas_id sidecar used to mask.
+        // Visibility timeout exceeds the worst-case PDF-export poll
+        // (60 attempts x 30s = 30 min) plus margin.
+        const packagingRequestDlq = new sqs.Queue(this, "PackagingRequestDLQ", {
+            fifo: true,
+            retentionPeriod: cdk.Duration.days(14),
+        });
+
+        const packagingRequestQueue = new sqs.Queue(this, "PackagingRequestQueue", {
+            fifo: true,
+            contentBasedDeduplication: true,
+            visibilityTimeout: cdk.Duration.minutes(40),
+            deadLetterQueue: {
+                queue: packagingRequestDlq,
+                maxReceiveCount: 3,
+            },
+        });
+
         // Build Fargate Service props using new config structure
         this.fargateService = new FargateService(this, "FargateService", {
             vpc,
@@ -303,6 +323,7 @@ export class BenchlingWebhookStack extends cdk.Stack {
             bucketWritePolicyArn: config.quilt.bucketWritePolicyArn,
             athenaUserPolicyArn: config.quilt.athenaUserPolicyArn,
             packageEventQueue,
+            packagingRequestQueue,
             // Legacy parameters
             benchlingSecret: benchlingSecretValue,
             packageBucket: packageBucketValue,

--- a/lib/fargate-service.ts
+++ b/lib/fargate-service.ts
@@ -41,6 +41,7 @@ export interface FargateServiceProps {
     readonly bucketWritePolicyArn?: string;
     readonly athenaUserPolicyArn?: string;
     readonly packageEventQueue?: sqs.IQueue;
+    readonly packagingRequestQueue?: sqs.IQueue;
 
     // Runtime-configurable parameters (from CloudFormation)
     readonly benchlingSecret: string;
@@ -308,6 +309,15 @@ export class FargateService extends Construct {
             props.packageEventQueue.grantConsumeMessages(taskRole);
         }
 
+        if (props.packagingRequestQueue) {
+            environmentVars.PACKAGING_REQUEST_QUEUE_URL = props.packagingRequestQueue.queueUrl;
+            environmentVars.PACKAGING_REQUEST_CONCURRENCY = "5";
+            environmentVars.PACKAGING_REQUEST_GRACEFUL_TIMEOUT = "30";
+            // Webhook container produces, packaging-consumer container drains.
+            props.packagingRequestQueue.grantSendMessages(taskRole);
+            props.packagingRequestQueue.grantConsumeMessages(taskRole);
+        }
+
         // Add container with configured environment
         const container = taskDefinition.addContainer("BenchlingWebhookContainer", {
             image: ecs.ContainerImage.fromEcrRepository(
@@ -339,6 +349,27 @@ export class FargateService extends Construct {
                 stopTimeout: cdk.Duration.seconds(30),
                 logging: ecs.LogDriver.awsLogs({
                     streamPrefix: "benchling-sqs-consumer",
+                    logGroup: this.logGroup,
+                }),
+                environment: environmentVars,
+            });
+        }
+
+        if (props.packagingRequestQueue) {
+            // Drains the FIFO packaging-request queue and runs
+            // EntryPackager.execute_workflow per message. FIFO + MessageGroupId
+            // serializes per-entry work; a single sidecar container processes
+            // up to PACKAGING_REQUEST_CONCURRENCY entries in parallel.
+            taskDefinition.addContainer("BenchlingPackagingConsumer", {
+                image: ecs.ContainerImage.fromEcrRepository(
+                    props.ecrRepository,
+                    props.imageTag || "latest",
+                ),
+                command: ["python", "-m", "src.packaging_consumer"],
+                essential: true,
+                stopTimeout: cdk.Duration.seconds(30),
+                logging: ecs.LogDriver.awsLogs({
+                    streamPrefix: "benchling-packaging-consumer",
                     logGroup: this.logGroup,
                 }),
                 environment: environmentVars,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quiltdata/benchling-webhook",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "AWS CDK deployment for Benchling webhook processing using Fargate - Deploy directly with npx",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quiltdata/benchling-webhook",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "AWS CDK deployment for Benchling webhook processing using Fargate - Deploy directly with npx",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/test/benchling-webhook-stack.test.ts
+++ b/test/benchling-webhook-stack.test.ts
@@ -37,19 +37,25 @@ describe("BenchlingWebhookStack", () => {
         });
     });
 
-    test("adds the SQS consumer sidecar to the task definition", () => {
+    test("adds the SQS consumer sidecars to the task definition", () => {
         const taskDefinitions = template.findResources("AWS::ECS::TaskDefinition");
         const taskDefinition = Object.values(taskDefinitions)[0] as any;
         const containerDefinitions = taskDefinition.Properties.ContainerDefinitions;
 
-        expect(containerDefinitions).toHaveLength(2);
+        // webhook + package-event consumer + packaging-request consumer
+        expect(containerDefinitions).toHaveLength(3);
 
-        const consumerContainer = containerDefinitions.find(
+        const packageEventConsumer = containerDefinitions.find(
             (container: any) => JSON.stringify(container.Command) === JSON.stringify(["python", "-m", "src.sqs_consumer"])
         );
+        expect(packageEventConsumer).toBeDefined();
+        expect(packageEventConsumer.Essential).toBe(true);
 
-        expect(consumerContainer).toBeDefined();
-        expect(consumerContainer.Essential).toBe(true);
+        const packagingConsumer = containerDefinitions.find(
+            (container: any) => JSON.stringify(container.Command) === JSON.stringify(["python", "-m", "src.packaging_consumer"])
+        );
+        expect(packagingConsumer).toBeDefined();
+        expect(packagingConsumer.Essential).toBe(true);
     });
 
     test("does not create Step Functions", () => {
@@ -84,7 +90,19 @@ describe("BenchlingWebhookStack", () => {
             }),
         });
 
-        template.resourceCountIs("AWS::SQS::Queue", 2);
+        // 4 queues: PackageEventQueue + DLQ, PackagingRequestQueue.fifo + DLQ
+        template.resourceCountIs("AWS::SQS::Queue", 4);
+    });
+
+    test("creates FIFO packaging-request queue with content-based dedup", () => {
+        template.hasResourceProperties("AWS::SQS::Queue", {
+            FifoQueue: true,
+            ContentBasedDeduplication: true,
+            VisibilityTimeout: 2400, // 40 minutes
+            RedrivePolicy: Match.objectLike({
+                maxReceiveCount: 3,
+            }),
+        });
     });
 
     test("creates CloudWatch log groups", () => {


### PR DESCRIPTION
## Summary

Three independent user-visible fixes landing as 0.17.2.

### 1. `sqs_consumer` waits for Benchling secrets instead of crashing ([ddf648f](https://github.com/quiltdata/benchling-webhook/commit/ddf648f))

Addresses the 🔴 \"CI `deploy_dev_stack` failing\" blocker sir-sigurd flagged on quiltdata/deployment#2357. Root cause lives here in the image, not in the deployment template.

Before: `sqs_consumer.main()` called `config.get_benchling_secrets()` unconditionally at startup. On a fresh deploy where `BenchlingSecret` is created empty by design (populated later by the external config script), the fetch raised `SecretsManagerError` → process exited → `Essential=True` cascaded → ECS Deployment Circuit Breaker tripped → `UPDATE_ROLLBACK_COMPLETE`.

The HTTP container is immune because it records the failure via `_runtime_guard_response` and keeps serving 503s. The sidecar had no equivalent safety net.

- **Pre-start readiness wait** (`docker/src/sqs_consumer.py`). Signal handlers installed before `wait_for_ready_config()` loops with bounded exponential backoff (30s → 300s) until `get_benchling_secrets()` + `apply_benchling_secrets()` succeed. `SIGTERM` short-circuits the wait via `asyncio.Event` so ECS can stop the container cleanly even during the wait. Catches both `SecretsManagerError` (secret empty/malformed) and `ValueError` (env var missing).
- **`MaxNumberOfMessages` = `min(10, concurrency)`** — default concurrency is 5; batching up to 10 would have 6–10th messages sitting in the semaphore backlog eating visibility timeout.

### 2. Canvas shows full layout with \"Updating...\" during export ([beb3b3c](https://github.com/quiltdata/benchling-webhook/commit/beb3b3c))

Replaces the bare \"Processing...\" placeholder canvas with the full navigation layout (Browse/Update buttons + package header + footer), where the footer reads \"Updating...\" until the background workflow delivers the real \"Updated at\" timestamp. Update Package is disabled while updating to prevent a second concurrent export; Browse Package stays enabled so the previous package version remains reachable on re-exports. Skips the linked-packages Athena query on the initial render to keep it fast on the request thread.

### 3. FIFO SQS per-entry sequencing replaces `.canvas_id` sidecar ([4e31324](https://github.com/quiltdata/benchling-webhook/commit/4e31324))

Webhook handlers used to fire-and-forget by spawning daemon threads, which let `entry.created` and `canvas.created` events for the same entry race to write `entry.json`. The `.canvas_id` S3 sidecar masked one symptom of that race (canvas_id loss), but the deeper issue was no per-entry sequencing.

Replace the daemon-thread \"queue\" with a real FIFO SQS queue keyed by `MessageGroupId=entry_id`. A new `BenchlingPackagingConsumer` sidecar drains the queue and runs `EntryPackager.execute_workflow`. Sequential processing per entry makes the sidecar unnecessary; a late entry event simply reads `canvas_id` from any existing `entry.json`.

- Add `PackagingRequestQueue.fifo` (+ DLQ) in CDK with 40-min visibility timeout and content-based dedup
- New `packaging_publisher` module: webhook handlers enqueue here
- New `packaging_consumer` module + Fargate sidecar that drains the queue
- Refactor `SqsConsumer` into a `BaseSqsConsumer` + two subclasses
- Delete `_save_canvas_id`, `_load_canvas_id`, `_load_canvas_id_sidecar`, and `execute_workflow_async`; existing `.canvas_id` files in S3 become harmless orphans
- Move synchronous `send_updating_canvas` into the canvas webhook handler

## Test plan

- [x] `npm test` — lint + typecheck + TS + Python unit tests
- [x] `npm run version:tag:dev` triggers CI image build
- [ ] `npm run test:dev` against deployed image
- [ ] Verify on quiltdata/deployment#2357 that `deploy_dev_stack` no longer trips circuit breaker on fresh deploy
- [x] Manual canvas export: confirm \"Updating...\" footer with Update disabled / Browse enabled
- [x] Manual concurrent `entry.created` + `canvas.created` replay: confirm `canvas_id` preserved in `entry.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)