### PR TITLE
ci: use deploy-ecr for production image publish

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build and push Docker image
         id: deploy
-        uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
+        uses: quiltdata/gh-actions/docker-build-publish@docker-build-publish
         with:
           dockerfile_path: docker/Dockerfile
           docker_context_path: docker

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      image_uri_sha: ${{ steps.image.outputs.IMAGE_URI_SHA }}
+      image_uri_sha: ${{ steps.deploy.outputs.image_uri_prod }}
       image_uri_latest: ${{ steps.image.outputs.IMAGE_URI_LATEST }}
       git_sha: ${{ steps.git.outputs.GIT_SHA }}
 
@@ -50,38 +50,31 @@ jobs:
         working-directory: docker
         run: uv sync --all-extras
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-benchling-webhook
-          aws-region: us-east-1
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
           platforms: linux/amd64
 
       - name: Build and push Docker image
-        working-directory: docker
-        run: make push-ci VERSION=${{ steps.git.outputs.GIT_SHA }}
-        env:
-          DOCKER_DEFAULT_PLATFORM: linux/amd64
-          AWS_REGION: us-east-1
+        id: deploy
+        uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
+        with:
+          dockerfile_path: docker/Dockerfile
+          docker_context_path: docker
+          docker_platform: linux/amd64
+          build_args: |
+            VERSION=${{ steps.git.outputs.GIT_SHA }}
+          image_name: quiltdata/benchling
+          additional_tags: '["latest"]'
+          push_targets: '["prod"]'
 
-      - name: Get Docker image URIs
+      - name: Record Docker image URIs
         id: image
         run: |
-          AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-          GIT_SHA="${{ steps.git.outputs.GIT_SHA }}"
-          IMAGE_URI_SHA="${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/quiltdata/benchling:${GIT_SHA}"
-          IMAGE_URI_LATEST="${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/quiltdata/benchling:latest"
-
-          echo "IMAGE_URI_SHA=$IMAGE_URI_SHA" >> $GITHUB_OUTPUT
-          echo "IMAGE_URI_LATEST=$IMAGE_URI_LATEST" >> $GITHUB_OUTPUT
-
+          echo "IMAGE_URI_LATEST=730278974607.dkr.ecr.us-east-1.amazonaws.com/quiltdata/benchling:latest" >> "$GITHUB_OUTPUT"
           echo "Docker Images:"
-          echo "  SHA: $IMAGE_URI_SHA"
-          echo "  Latest: $IMAGE_URI_LATEST"
+          echo "  SHA: ${{ steps.deploy.outputs.image_uri_prod }}"
+          echo "  Latest: 730278974607.dkr.ecr.us-east-1.amazonaws.com/quiltdata/benchling:latest"
 
   validate:
     name: Validate Production Image


### PR DESCRIPTION
## Summary

Migrates `.github/workflows/prod.yml` to the unified `deploy-ecr` action on `quiltdata/gh-actions/deploy-ecr@deploy-ecr`.

Behavior preserved:

- image name remains `quiltdata/benchling`
- push target remains Prod only
- the workflow still pushes both the checked-out HEAD SHA tag and `latest`
- Docker build remains `linux/amd64`
- `VERSION=<git sha>` is still passed as a Docker build arg
- validation still checks the SHA image and the `latest` tag

## Notes

This follows the migration plan in `07-unify-deploy-ecr.md`. `_VERSIONS` keys were not found in this repo; image name was preserved from the existing workflow ECR URI.

The previous workflow only built, pushed, and validated the image; it did not run `aws ecs update-service`, so this PR does not add `cluster_name` / `service_name` deployment inputs.

## Validation

- Parsed workflow YAML with Ruby `YAML.load_file`
- `git diff --check HEAD~1..HEAD`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the manual build/push steps in `prod.yml` with the unified `quiltdata/gh-actions/deploy-ecr@deploy-ecr` composite action, preserving the image name, platform, build args, and tags.

- The explicit `aws-actions/configure-aws-credentials` step was removed from `build-and-push` with no `role_to_assume` or equivalent input passed to the `deploy-ecr` action — if the action does not handle OIDC auth internally, the ECR push will fail.

<h3>Confidence Score: 3/5</h3>

Hold for confirmation that deploy-ecr handles OIDC authentication internally before merging.

A P1 finding exists: the explicit AWS credential step was removed from the build job and no role ARN is passed to the deploy-ecr action. If the action requires pre-configured credentials, the workflow will fail on every push to main.

.github/workflows/prod.yml — specifically the build-and-push job and its credential setup

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/prod.yml | Migrates build/push to the unified deploy-ecr action; removes explicit AWS credential configuration from the build job without passing equivalent inputs to the action, which may cause ECR auth failure |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant DE as deploy-ecr action
    participant ECR as AWS ECR (Prod)
    participant V as validate job

    GH->>GH: Checkout & Extract git SHA
    GH->>GH: Set up Python / uv
    GH->>GH: Set up Docker Buildx
    GH->>DE: uses: deploy-ecr (image_name, build_args, push_targets=prod)
    Note over DE,ECR: AWS auth handled internally?
    DE->>ECR: docker build & push (SHA tag + latest)
    DE-->>GH: outputs.image_uri_prod
    GH->>GH: Record IMAGE_URI_LATEST (hardcoded account ID)
    GH->>V: needs: build-and-push (image_uri_sha, git_sha)
    V->>ECR: Pull & validate image (architecture + startup)
```

<sub>Reviews (1): Last reviewed commit: ["Use deploy-ecr for production image publ..."](https://github.com/quiltdata/benchling-webhook/commit/58496f33cb3ed30206c741b651e68d6f54220174) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30132108)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->