### PR TITLE
feat: auto_packaging toggle via Benchling App Config settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `["quilt", "settings", "auto_packaging"]` App Configuration Item: when set to `false`, entry and canvas lifecycle events no longer auto-enqueue packaging; the canvas renders with the Update Package button for manual, per-entry packaging. Defaults to `true` (existing behavior) when unset
+- `/config` endpoint now reports the effective `auto_packaging` value
+
+### Fixed
+
+- Unknown canvas button interactions now return an explicit `ignored` response instead of falling through to the packaging path, which previously enqueued unintended packaging work
+
 ## [0.19.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -236,9 +236,13 @@ App Configuration Items are read under the `["quilt"]` path namespace:
 - `["quilt", "default", "bucket" | "prefix" | "package_key" | "workflow"]`
 - `["quilt", "routing", "<event-type>", "<key>"]`
 - `["quilt", "projects", "<project-name>", "<key>"]`
-- `["quilt", "settings", "log_level" | "package_event_concurrency" | "packaging_request_concurrency"]`
+- `["quilt", "settings", "log_level" | "package_event_concurrency" | "packaging_request_concurrency" | "auto_packaging"]`
 
 Project routing is merged field-by-field over event defaults, global defaults, and legacy secret values. For example, a project rule that sets only `bucket` inherits `prefix`, `package_key`, and `workflow` from lower-priority tiers.
+
+### Disabling automatic packaging
+
+Setting `["quilt", "settings", "auto_packaging"]` to `false` stops entry and canvas lifecycle events from automatically enqueueing packaging work. The canvas still renders with the Update Package button, so scientists trigger packaging manually per entry. Button-driven packaging (Update Package) always works regardless of this setting. Defaults to `true` (current behavior) when unset. Toggling the item in the Benchling UI takes effect within one config-cache interval, or immediately when Benchling delivers a `configuration.updated` lifecycle event.
 
 CLI helpers:
 

--- a/docker/app-manifest.yaml
+++ b/docker/app-manifest.yaml
@@ -19,3 +19,8 @@ subscriptions:
     - type: v2.entry.updated.fields
     - type: v2.entry.updated.reviewRecord
 #  - type: v2.entity.registered
+
+#  App Configuration lifecycle event: when the operator toggles a ["quilt"]
+#  App Config Item in the Benchling UI, the config cache is invalidated
+#  immediately so the new value is picked up on the next webhook event.
+    - type: v2-beta.app.configuration.updated

--- a/docker/scripts/app_config.py
+++ b/docker/scripts/app_config.py
@@ -113,6 +113,7 @@ def seed_items(
         (["quilt", "settings", "log_level"], logging_config.get("level") or secrets.log_level or "INFO"),
         (["quilt", "settings", "package_event_concurrency"], "5"),
         (["quilt", "settings", "packaging_request_concurrency"], "5"),
+        (["quilt", "settings", "auto_packaging"], "true"),
     ]
 
     existing_by_path = {tuple(item_path(item)): getattr(item, "id", None) for item in existing_items}

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -606,6 +606,7 @@ def create_app() -> FastAPI:
                     "user_bucket": None,
                     "log_level": os.getenv("LOG_LEVEL", "INFO"),
                     "enable_webhook_verification": False,
+                    "auto_packaging": None,
                 }
                 return degraded
 
@@ -667,6 +668,7 @@ def create_app() -> FastAPI:
                     "user_bucket": config.s3_bucket_name,
                     "log_level": config.log_level,
                     "enable_webhook_verification": config.enable_webhook_verification,
+                    "auto_packaging": config.auto_packaging,
                 },
             }
 
@@ -708,6 +710,41 @@ def create_app() -> FastAPI:
         except Exception as exc:
             logger.warning(
                 "Failed to send initial 'Updating...' canvas",
+                canvas_id=payload.canvas_id,
+                error=str(exc),
+            )
+
+    def _resolve_auto_packaging(payload: Payload) -> bool:
+        """Resolve auto_packaging from Tier 1 App Config for this event.
+
+        Defaults to True (current behavior) when unset or when config lookup
+        fails, so a Benchling API hiccup never silently drops packaging work.
+        """
+        assert benchling is not None and config is not None
+        try:
+            secrets = config.get_benchling_secrets()
+            return config.resolve_auto_packaging(benchling, secrets)
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve auto_packaging setting; defaulting to enabled",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            return True
+
+    def _render_canvas_without_packaging(payload: Payload) -> None:
+        """Render/refresh the canvas without enqueueing packaging work.
+
+        Used when auto_packaging is disabled: the canvas still appears with
+        the Update Package button so scientists can trigger packaging manually.
+        """
+        assert benchling is not None and config is not None
+        try:
+            canvas_manager = CanvasManager(benchling, config, payload)
+            canvas_manager.handle_async()
+        except Exception as exc:
+            logger.warning(
+                "Failed to render canvas without packaging",
                 canvas_id=payload.canvas_id,
                 error=str(exc),
             )
@@ -764,6 +801,17 @@ def create_app() -> FastAPI:
                     event_type=payload.event_type,
                     canvas_id=payload.canvas_id,
                 )
+                if not _resolve_auto_packaging(payload):
+                    logger.info(
+                        "auto_packaging disabled - rendering canvas without packaging",
+                        canvas_id=payload.canvas_id,
+                        event_type=payload.event_type,
+                    )
+                    _render_canvas_without_packaging(payload)
+                    return JSONResponse(
+                        {"status": "ACCEPTED", "message": "Canvas rendered without packaging"},
+                        status_code=202,
+                    )
                 _send_updating_canvas_best_effort(payload)
                 routing = _resolve_payload_routing(payload)
                 publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload, routing)
@@ -784,6 +832,18 @@ def create_app() -> FastAPI:
                 return {
                     "status": "ignored",
                     "message": f"Event type {payload.event_type} not processed",
+                }
+
+            if not _resolve_auto_packaging(payload):
+                logger.info(
+                    "auto_packaging disabled - entry event will not trigger packaging",
+                    entry_id=payload.entry_id,
+                    event_type=payload.event_type,
+                )
+                return {
+                    "entry_id": payload.entry_id,
+                    "status": "skipped",
+                    "message": "auto_packaging is disabled; use the canvas Update Package button",
                 }
 
             routing = _resolve_payload_routing(payload)
@@ -926,7 +986,26 @@ def create_app() -> FastAPI:
                 if button_id.startswith("update-package-"):
                     return handle_update_package(payload, entry_packager, benchling, config)
 
+                # Unknown buttons must not fall through to the packaging path below:
+                # with auto_packaging on that would enqueue unintended work, and with
+                # it off it would silently re-render the canvas.
                 logger.warning("Unknown button action from /canvas", button_id=button_id)
+                return JSONResponse(
+                    {"status": "ignored", "message": f"Unknown button action: {button_id}"},
+                    status_code=200,
+                )
+
+            if not _resolve_auto_packaging(payload):
+                logger.info(
+                    "auto_packaging disabled - rendering canvas without packaging",
+                    canvas_id=payload.canvas_id,
+                    event_type=payload.event_type,
+                )
+                _render_canvas_without_packaging(payload)
+                return JSONResponse(
+                    {"status": "ACCEPTED", "message": "Canvas rendered without packaging"},
+                    status_code=202,
+                )
 
             _send_updating_canvas_best_effort(payload)
             sqs_message_id = publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)

--- a/docker/src/config.py
+++ b/docker/src/config.py
@@ -61,6 +61,10 @@ class Config:
     quilt_write_role_arn: str = ""
     package_event_concurrency: int = 5
     packaging_request_concurrency: int = 5
+    # When False, entry events render/refresh the canvas but do not enqueue
+    # packaging work; scientists trigger packaging via the canvas button.
+    # Configured via Benchling App Config: ["quilt", "settings", "auto_packaging"]
+    auto_packaging: bool = True
 
     # Secret fetching infrastructure (not the secrets themselves)
     _benchling_secret_name: str = ""
@@ -356,6 +360,21 @@ class Config:
             self.package_event_concurrency = routing_config.settings.package_event_concurrency
         if routing_config.settings.packaging_request_concurrency:
             self.packaging_request_concurrency = routing_config.settings.packaging_request_concurrency
+        if routing_config.settings.auto_packaging is not None:
+            self.auto_packaging = routing_config.settings.auto_packaging
+
+    def resolve_auto_packaging(self, benchling: Any, secret_data: BenchlingSecretData) -> bool:
+        """Resolve the auto_packaging setting from Tier 1 App Config at event time.
+
+        Reads through the TTL routing cache so toggling
+        ["quilt", "settings", "auto_packaging"] in the Benchling UI takes effect
+        within one cache interval (or immediately on configuration.updated).
+        Defaults to True when unset.
+        """
+        routing_config = self.get_routing_config(benchling, secret_data)
+        if routing_config.settings.auto_packaging is not None:
+            return routing_config.settings.auto_packaging
+        return self.auto_packaging
 
     def resolve_effective_routing(
         self,

--- a/docker/src/routing_config.py
+++ b/docker/src/routing_config.py
@@ -58,6 +58,7 @@ class RuntimeSettings:
     log_level: str | None = None
     package_event_concurrency: int | None = None
     packaging_request_concurrency: int | None = None
+    auto_packaging: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -313,6 +314,7 @@ def _settings_from_mapping(values: Any) -> RuntimeSettings:
         log_level=_string_value(values, "log_level", "logLevel"),
         package_event_concurrency=_int_value(values.get("package_event_concurrency")),
         packaging_request_concurrency=_int_value(values.get("packaging_request_concurrency")),
+        auto_packaging=_bool_value(values.get("auto_packaging")),
     )
 
 
@@ -324,3 +326,20 @@ def _int_value(value: Any) -> int | None:
     except (TypeError, ValueError):
         return None
     return parsed if parsed > 0 else None
+
+
+def _bool_value(value: Any) -> bool | None:
+    """Parse a boolean from App Config item values (stored as text).
+
+    Returns None for unset/unrecognized values so callers can distinguish
+    "not configured" from an explicit true/false.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "1", "yes", "on"):
+            return True
+        if lowered in ("false", "0", "no", "off"):
+            return False
+    return None

--- a/docker/tests/test_app.py
+++ b/docker/tests/test_app.py
@@ -164,6 +164,65 @@ class TestFastAPIApp:
         published_payload = mock_publish.call_args.args[2]
         assert published_payload.canvas_id == "canvas_123"
 
+    def test_entry_event_skipped_when_auto_packaging_disabled(self, client, mock_config, mock_publish):
+        """Entry events must not enqueue packaging when auto_packaging is off."""
+        mock_config.resolve_auto_packaging.return_value = False
+        payload = {
+            "channel": "events",
+            "message": {"type": "v2.entry.updated.fields", "resourceId": "etr_123456"},
+            "baseURL": "https://tenant.benchling.com",
+        }
+
+        response = client.post("/event", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "skipped"
+        mock_publish.assert_not_called()
+
+    def test_canvas_event_renders_without_packaging_when_disabled(self, client, mock_config, mock_publish):
+        """Canvas lifecycle events render the canvas but skip packaging when auto_packaging is off."""
+        mock_config.resolve_auto_packaging.return_value = False
+        payload = {
+            "channel": "events",
+            "message": {"type": "v2.canvas.initialized", "resourceId": "etr_123456"},
+            "baseURL": "https://tenant.benchling.com",
+            "context": {"canvasId": "canvas_123"},
+        }
+
+        with patch("src.app.CanvasManager") as mock_canvas_manager:
+            mock_manager_instance = MagicMock()
+            mock_canvas_manager.return_value = mock_manager_instance
+
+            response = client.post("/canvas", json=payload)
+
+            assert response.status_code == 202
+            data = response.json()
+            assert data["status"] == "ACCEPTED"
+            assert "without packaging" in data["message"]
+            mock_manager_instance.handle_async.assert_called_once()
+
+        mock_publish.assert_not_called()
+
+    def test_unknown_button_returns_ignored_without_packaging(self, client, mock_publish):
+        """Unknown canvas buttons must not fall through to the packaging path."""
+        payload = {
+            "channel": "app_signals",
+            "message": {
+                "type": "v2.canvas.userInteracted",
+                "buttonId": "some-unknown-button-etr_123",
+                "canvasId": "canvas_abc",
+            },
+            "baseURL": "https://tenant.benchling.com",
+        }
+
+        response = client.post("/canvas", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ignored"
+        mock_publish.assert_not_called()
+
     @pytest.mark.local
     def test_canvas_endpoint_handles_browse_files_button(self, client, mock_benchling_client):
         """Test /canvas endpoint routes Browse Files button to correct handler.

--- a/docker/tests/test_routing_config.py
+++ b/docker/tests/test_routing_config.py
@@ -62,3 +62,23 @@ def test_find_app_id_matches_app_definition_id():
     benchling = SimpleNamespace(apps=SimpleNamespace(list_apps=lambda: [[app]]))
 
     assert find_app_id(benchling, "appdef_123") == "app_123"
+
+
+def test_settings_parse_auto_packaging_true_false_and_unset():
+    config_true = RoutingConfig.from_app_configuration_items(
+        [item(["quilt", "settings", "auto_packaging"], "true")]
+    )
+    config_false = RoutingConfig.from_app_configuration_items(
+        [item(["quilt", "settings", "auto_packaging"], "False")]
+    )
+    config_unset = RoutingConfig.from_app_configuration_items(
+        [item(["quilt", "default", "bucket"], "some-bucket")]
+    )
+    config_garbage = RoutingConfig.from_app_configuration_items(
+        [item(["quilt", "settings", "auto_packaging"], "maybe")]
+    )
+
+    assert config_true.settings.auto_packaging is True
+    assert config_false.settings.auto_packaging is False
+    assert config_unset.settings.auto_packaging is None
+    assert config_garbage.settings.auto_packaging is None


### PR DESCRIPTION
## Summary

Adds a runtime `auto_packaging` toggle to the three-tier routing system, configured via Benchling App Configuration Items rather than AWS Secrets Manager.

### What changes

- **New App Config setting**: `["quilt", "settings", "auto_packaging"]` — when `false`, entry events (`v2.entry.*`) and canvas lifecycle events (`v2.canvas.initialized`, `v2.canvas.created`) no longer automatically enqueue packaging work. The canvas renders with the Update Package button so scientists trigger packaging per-entry.
- **Defaults to `true`**: existing behavior is preserved when the setting is absent or unrecognized.
- **Fail-open on config errors**: if the Benchling App Config lookup fails, packaging stays enabled so an API hiccup never silently drops work.
- **Immediate toggle**: the manifest now subscribes to `v2-beta.app.configuration.updated`, so toggling the value in the Benchling UI takes effect on the next event (no restart, no60s cache wait).
- **Button-driven packaging unaffected**: the Update Package button always enqueues packaging regardless of the setting.

### Bugfix included

Unknown canvas button interactions now return an explicit `{"status": "ignored"}` response instead of falling through to the packaging path. Previously, an unrecognized `buttonId` would enqueue unintended packaging work (with `auto_packaging` true) or silently re-render the canvas (with `auto_packaging` false).

### Files to focus your review on

| File | Change |
|------|--------|
| `docker/src/routing_config.py` | `RuntimeSettings.auto_packaging: bool \| None`, `_bool_value()` parser |
| `docker/src/config.py` | `Config.auto_packaging`, `resolve_auto_packaging()` method |
| `docker/src/app.py` | `_resolve_auto_packaging()`, `_render_canvas_without_packaging()`, unknown-button early return |
| `docker/app-manifest.yaml` | Subscribe to `v2-beta.app.configuration.updated` |
| `docker/scripts/app_config.py` | Seed default `["quilt", "settings", "auto_packaging"]` as `"true"` |
| `docker/tests/test_routing_config.py` | Settings parsing tests for true/false/unset/garbage |
| `docker/tests/test_app.py` | Entry skipped, canvas renders without packaging, unknown button ignored |

### Relationship to PR #393

This supersedes the Secrets-Manager-based `auto_packaging` from #393. That PR routed configuration through `BenchlingSecretData` and `sync-secrets.ts`; this PR follows the platform-config-first principle discussed in the #engineering thread: all configurable behavior lives in the platform (Benchling App Config), not in AWS console configuration. Closing #393 in favor of this PR.

## Test plan

- [x] `docker/tests/test_routing_config.py`: `auto_packaging` parses `"true"`, `"False"`, unset, garbage
- [x] `docker/tests/test_app.py`: entry event returns `skipped` when `auto_packaging` is off
- [x] `docker/tests/test_app.py`: canvas lifecycle renders without packaging when off
- [x] `docker/tests/test_app.py`: unknown button returns `ignored` without enqueuing packaging
- [x] Full suite: `414 passed, 37 deselected`
- [ ] Deploy to `bench.dev.quilttest.com`, toggle `auto_packaging` via Benchling UI, verify entry events no longer auto-package and Update Package button still works

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a runtime `auto_packaging` toggle controlled by the `["quilt", "settings", "auto_packaging"]` Benchling App Config Item, wired through the existing three-tier routing/cache system. When disabled, entry and canvas lifecycle events render the canvas without enqueueing SQS work; the Update Package button is always unaffected. Also fixes a pre-existing bug where unrecognised canvas `buttonId` values would fall through to the packaging path.

- **`routing_config.py`**: New `_bool_value()` parser and `RuntimeSettings.auto_packaging: bool | None` field, with clear None-as-unset semantics.
- **`config.py`**: `resolve_auto_packaging()` reads the TTL cache and falls back to the startup-time value; `apply_global_routing_config` propagates the setting at startup.
- **`app.py`**: `_resolve_auto_packaging()` wraps the config call with a fail-open exception handler; guards are inserted at the three relevant event paths; `_render_canvas_without_packaging()` handles the canvas-only render; unknown buttons now return `{"status": "ignored"}` instead of falling through.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only finding is a cosmetic dead-parameter in a helper function. Core logic, cache behaviour, and fail-open default are all sound.

The toggle logic is straightforward and well-isolated behind the existing TTL-cache layer. The unknown-button fix is clearly correct. The single comment is about an unused `payload` argument in `_resolve_auto_packaging` that doesn't affect runtime behaviour — removing it would improve clarity but nothing breaks with it present.

docker/src/app.py — minor cleanup of the unused parameter in _resolve_auto_packaging and its three call-sites.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/src/app.py | Adds _resolve_auto_packaging and _render_canvas_without_packaging helpers; inserts auto_packaging guards in /event and /canvas handlers; fixes unknown-button fall-through. The payload parameter in _resolve_auto_packaging is unused. |
| docker/src/config.py | Adds auto_packaging field (default True), propagates it in apply_global_routing_config, and adds resolve_auto_packaging() which reads the TTL-cached routing config and falls back to the startup-time value. |
| docker/src/routing_config.py | Adds auto_packaging: bool | None to RuntimeSettings and a _bool_value() parser that correctly returns None for unrecognised/unset values; well-tested. |
| docker/app-manifest.yaml | Subscribes to v2-beta.app.configuration.updated; Benchling routing convention for v2-beta.app.* events should deliver it to /lifecycle (already handled), but the routing relies on Benchling's prefix conventions. |
| docker/tests/test_app.py | Adds three new tests covering the auto_packaging disabled path for entry events, canvas lifecycle events, and the unknown-button early-return fix. Tests are clear and correctly mock resolve_auto_packaging. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming webhook event] --> B{Endpoint}
    B -->|canvas events| C[canvas handler]
    B -->|entry events| D[event handler]
    B -->|config.updated lifecycle| E[lifecycle handler]
    E --> E1[config.invalidate_routing_config]
    C --> F{userInteracted?}
    F -->|Yes| G{Known buttonId?}
    G -->|browse, page, back, metadata| H[Handle button action]
    G -->|update-package| I[handle_update_package - enqueue]
    G -->|unknown| J[Return ignored - NEW FIX]
    F -->|No - lifecycle event| K{_resolve_auto_packaging}
    K -->|False| L[render canvas without packaging Return 202]
    K -->|True| M[send updating canvas + publish_packaging_request Return 202]
    D --> N{event_type supported?}
    N -->|No| O[Return ignored]
    N -->|Yes| P{_resolve_auto_packaging}
    P -->|False| Q[Return skipped - NEW]
    P -->|True| R[publish_packaging_request - Return ACCEPTED]
    subgraph resolve[_resolve_auto_packaging closure]
        S[get_benchling_secrets] --> T[resolve_auto_packaging via TTL cache]
        T --> U{value in cache?}
        U -->|yes| V[return cached bool]
        U -->|no| W[return config.auto_packaging startup default]
        S -->|Exception| X[return True fail open]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming webhook event] --> B{Endpoint}
    B -->|canvas events| C[canvas handler]
    B -->|entry events| D[event handler]
    B -->|config.updated lifecycle| E[lifecycle handler]
    E --> E1[config.invalidate_routing_config]
    C --> F{userInteracted?}
    F -->|Yes| G{Known buttonId?}
    G -->|browse, page, back, metadata| H[Handle button action]
    G -->|update-package| I[handle_update_package - enqueue]
    G -->|unknown| J[Return ignored - NEW FIX]
    F -->|No - lifecycle event| K{_resolve_auto_packaging}
    K -->|False| L[render canvas without packaging Return 202]
    K -->|True| M[send updating canvas + publish_packaging_request Return 202]
    D --> N{event_type supported?}
    N -->|No| O[Return ignored]
    N -->|Yes| P{_resolve_auto_packaging}
    P -->|False| Q[Return skipped - NEW]
    P -->|True| R[publish_packaging_request - Return ACCEPTED]
    subgraph resolve[_resolve_auto_packaging closure]
        S[get_benchling_secrets] --> T[resolve_auto_packaging via TTL cache]
        T --> U{value in cache?}
        U -->|yes| V[return cached bool]
        U -->|no| W[return config.auto_packaging startup default]
        S -->|Exception| X[return True fail open]
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(app-manifest): subscribe to configu..."](https://github.com/quiltdata/benchling-webhook/commit/fca61cfac3c2ad7e005a932fa04138bdce6382c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41661033)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->