### PR TITLE
Support bucketless Benchling webhook deployments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,17 @@ npm run test:local:prod      # AFTER DOCKER PROD CHANGES
 npm run test:dev             # AFTER CI BUILDS IMAGE (needs git tag first)
 ```
 
-CI build trigger: `npm run version:tag:dev`
+## Tagging: Dev vs Release Builds
+
+Both commands run `version:verify` (clean git check) and the full `npm test` suite before creating and pushing a git tag, which triggers a CI Docker build.
+
+```bash
+npm run version:tag:dev      # DEV BUILDS — pre-release tag `v<version>-<timestamp>`
+npm run version:tag          # RELEASE BUILDS — production tag `v<version>`
+```
+
+- **`version:tag:dev`** — use for iterative/dev builds. Appends a timestamp so the tag is always unique; you can re-tag the same version repeatedly. Produces a pre-release (dev) build. This is the CI build trigger to use while testing changes (e.g. before `npm run test:dev`).
+- **`version:tag`** — use for official releases only. Creates `v<version>` (no timestamp), so the version must be bumped first (`npm run version -- patch|minor|major`) or the tag will already exist. Triggers the production release build (GitHub release + NPM publish).
 
 ## Gotchas
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-03
+
+### Added
+
+- Bucketless deployments are now supported: the package bucket configuration is optional, setup and secret creation can omit it, and runtime entry/canvas events skip default package creation when no bucket is configured.
+- Linked package discovery now searches all available Quilt package-view buckets in bucketless mode and preserves the source bucket when browsing linked package files or metadata from Benchling canvases.
+
+### Changed
+
+- Bucket-specific S3 IAM permissions are only added when a package bucket is configured, avoiding invalid empty-bucket resource ARNs for bucketless stacks.
+
 ## [0.18.0] - 2026-06-15
 
 ### Added

--- a/bin/commands/create-secret.ts
+++ b/bin/commands/create-secret.ts
@@ -150,11 +150,12 @@ async function createOrUpdateSecret(
     const secretString = JSON.stringify(secretData, null, 2);
 
     if (dryRun) {
+        const maskedData = { ...secretData, client_secret: "***REDACTED***" };
         console.log(chalk.blue("\n🔍 DRY RUN MODE - No changes will be made\n"));
         console.log(chalk.cyan("Secret Name:"), secretName);
         console.log(chalk.cyan("Region:"), region);
         console.log(chalk.cyan("Secret Content:"));
-        console.log(chalk.gray(secretString));
+        console.log(chalk.gray(JSON.stringify(maskedData, null, 2)));
         return;
     }
 

--- a/bin/commands/create-secret.ts
+++ b/bin/commands/create-secret.ts
@@ -43,7 +43,7 @@ interface BenchlingSecretData {
   app_definition_id: string;
   pkg_prefix: string;
   pkg_key: string;
-  user_bucket: string;
+  user_bucket?: string;
   log_level: string;
   enable_webhook_verification: string;
   webhook_allow_list: string;
@@ -56,7 +56,6 @@ const REQUIRED_PARAMS = [
     "BENCHLING_APP_DEFINITION_ID",
     "BENCHLING_PKG_PREFIX",
     "BENCHLING_PKG_KEY",
-    "BENCHLING_USER_BUCKET",
     "BENCHLING_LOG_LEVEL",
     "BENCHLING_ENABLE_WEBHOOK_VERIFICATION",
     "BENCHLING_WEBHOOK_ALLOW_LIST",
@@ -122,7 +121,7 @@ function validateParameters(params: Record<string, string>): BenchlingSecretData
         app_definition_id: params.BENCHLING_APP_DEFINITION_ID,
         pkg_prefix: params.BENCHLING_PKG_PREFIX,
         pkg_key: params.BENCHLING_PKG_KEY,
-        user_bucket: params.BENCHLING_USER_BUCKET,
+        ...(params.BENCHLING_USER_BUCKET ? { user_bucket: params.BENCHLING_USER_BUCKET } : {}),
         log_level: logLevel,
         enable_webhook_verification: verification,
         webhook_allow_list: params.BENCHLING_WEBHOOK_ALLOW_LIST,
@@ -228,7 +227,7 @@ async function main(): Promise<void> {
     console.log(chalk.gray(`  app_definition_id: ${secretData.app_definition_id}`));
     console.log(chalk.gray(`  pkg_prefix: ${secretData.pkg_prefix}`));
     console.log(chalk.gray(`  pkg_key: ${secretData.pkg_key}`));
-    console.log(chalk.gray(`  user_bucket: ${secretData.user_bucket}`));
+    console.log(chalk.gray(`  user_bucket: ${secretData.user_bucket || "(bucketless mode)"}`));
     console.log(chalk.gray(`  log_level: ${secretData.log_level}`));
     console.log(chalk.gray(`  enable_webhook_verification: ${secretData.enable_webhook_verification}`));
     console.log(chalk.gray(`  webhook_allow_list: ${secretData.webhook_allow_list || "(empty)"}`));

--- a/bin/commands/deploy.ts
+++ b/bin/commands/deploy.ts
@@ -796,6 +796,7 @@ export async function deploy(
             `PackageBucket=${config.packages.bucket || ""}`,
             `QuiltDatabase=${config.quilt.database || ""}`,  // IAM permissions only (same value as AthenaUserDatabase)
             `LogLevel=${config.logging?.level || "INFO"}`,
+            `IcebergDatabase=${(config.quilt as Record<string, unknown>).icebergDatabase as string || ""}`,
         ];
 
         const parametersArg = parameters.map(p => `--parameters ${p}`).join(" ");

--- a/bin/commands/deploy.ts
+++ b/bin/commands/deploy.ts
@@ -796,7 +796,7 @@ export async function deploy(
             `PackageBucket=${config.packages.bucket || ""}`,
             `QuiltDatabase=${config.quilt.database || ""}`,  // IAM permissions only (same value as AthenaUserDatabase)
             `LogLevel=${config.logging?.level || "INFO"}`,
-            `IcebergDatabase=${(config.quilt as Record<string, unknown>).icebergDatabase as string || ""}`,
+            `IcebergDatabase=${(config.quilt as unknown as Record<string, string>).icebergDatabase || ""}`,
         ];
 
         const parametersArg = parameters.map(p => `--parameters ${p}`).join(" ");

--- a/bin/commands/deploy.ts
+++ b/bin/commands/deploy.ts
@@ -88,38 +88,42 @@ async function checkStackStatus(region: string, stackName: string): Promise<Stac
     }
 }
 
-async function resolveQuiltAthenaWorkgroup(
+async function resolveQuiltDeploymentResources(
     stackArn: string,
     region: string,
     quiltStackName: string,
-): Promise<string | undefined> {
+): Promise<Pick<QuiltServices, "athenaUserWorkgroup" | "icebergDatabase">> {
     try {
         const resources = await getStackResources(region, stackArn);
         const discovered = extractQuiltResources(resources);
         const workgroup = discovered.athenaUserWorkgroup;
+        const result: Pick<QuiltServices, "athenaUserWorkgroup" | "icebergDatabase"> = {};
 
-        if (!workgroup) {
-            return undefined;
+        if (workgroup) {
+            const expectedPrefix = `${quiltStackName}-`;
+            if (!workgroup.startsWith(expectedPrefix)) {
+                console.log(
+                    chalk.yellow(
+                        `⚠️  Ignoring Athena workgroup '${workgroup}' (expected prefix '${expectedPrefix}')`,
+                    ),
+                );
+            } else {
+                result.athenaUserWorkgroup = workgroup;
+            }
         }
 
-        const expectedPrefix = `${quiltStackName}-`;
-        if (!workgroup.startsWith(expectedPrefix)) {
-            console.log(
-                chalk.yellow(
-                    `⚠️  Ignoring Athena workgroup '${workgroup}' (expected prefix '${expectedPrefix}')`,
-                ),
-            );
-            return undefined;
+        if (discovered.icebergDatabase) {
+            result.icebergDatabase = discovered.icebergDatabase;
         }
 
-        return workgroup;
+        return result;
     } catch (error) {
         console.log(
             chalk.yellow(
-                `⚠️  Failed to discover Athena workgroup from Quilt stack: ${(error as Error).message}`,
+                `⚠️  Failed to discover Quilt resources from Quilt stack: ${(error as Error).message}`,
             ),
         );
-        return undefined;
+        return {};
     }
 }
 
@@ -608,24 +612,30 @@ export async function deploy(
 
     spinner.succeed("Quilt configuration loaded");
 
-    spinner.start("Resolving Quilt Athena workgroup...");
-    const discoveredAthenaWorkgroup = await resolveQuiltAthenaWorkgroup(
+    spinner.start("Resolving Quilt deployment resources...");
+    const discoveredResources = await resolveQuiltDeploymentResources(
         stackArn,
         deployRegion,
         parsed.stackName,
     );
-    if (discoveredAthenaWorkgroup) {
-        spinner.succeed(`Resolved Athena workgroup: ${discoveredAthenaWorkgroup}`);
+    if (discoveredResources.athenaUserWorkgroup) {
+        spinner.succeed(`Resolved Athena workgroup: ${discoveredResources.athenaUserWorkgroup}`);
     } else {
         spinner.succeed("No Quilt-managed Athena workgroup found; will create one in webhook stack");
     }
+    if (discoveredResources.icebergDatabase && !config.quilt.icebergDatabase) {
+        console.log(chalk.dim(`✓ Resolved Iceberg database from Quilt stack: ${discoveredResources.icebergDatabase}`));
+    }
+
+    const icebergDatabase = config.quilt.icebergDatabase || discoveredResources.icebergDatabase || "";
 
     // Convert to QuiltServices format for display
     const services: QuiltServices = {
         packagerQueueUrl: config.quilt.queueUrl,
         athenaUserDatabase: config.quilt.database,
         quiltWebHost: config.quilt.catalog,
-        athenaUserWorkgroup: discoveredAthenaWorkgroup,
+        athenaUserWorkgroup: discoveredResources.athenaUserWorkgroup,
+        ...(icebergDatabase && { icebergDatabase }),
     };
 
     // Build ECR image URI for display
@@ -657,6 +667,11 @@ export async function deploy(
         console.log(`    ${chalk.bold("Athena Workgroup:")}        ${services.athenaUserWorkgroup}`);
     } else {
         console.log(`    ${chalk.bold("Athena Workgroup:")}        ${stackName}-athena-workgroup ${chalk.dim("(webhook-managed)")}`);
+    }
+    if (services.icebergDatabase) {
+        console.log(`    ${chalk.bold("Iceberg Database:")}       ${services.icebergDatabase}`);
+    } else {
+        console.log(`    ${chalk.bold("Iceberg Database:")}       ${chalk.gray("(not configured; legacy fanout fallback)")}`);
     }
     console.log();
     console.log(chalk.bold("  Stack Parameters:"));
@@ -767,7 +782,13 @@ export async function deploy(
         };
 
         // Transform ProfileConfig → StackConfig (minimal interface)
-        const stackConfig = profileToStackConfig(deployConfig);
+        const stackConfig = profileToStackConfig({
+            ...deployConfig,
+            quilt: {
+                ...deployConfig.quilt,
+                ...(icebergDatabase ? { icebergDatabase } : {}),
+            },
+        });
         const result = createStack(stackConfig, {
             account: deployAccount,
             region: deployRegion,
@@ -796,7 +817,7 @@ export async function deploy(
             `PackageBucket=${config.packages.bucket || ""}`,
             `QuiltDatabase=${config.quilt.database || ""}`,  // IAM permissions only (same value as AthenaUserDatabase)
             `LogLevel=${config.logging?.level || "INFO"}`,
-            `IcebergDatabase=${(config.quilt as unknown as Record<string, string>).icebergDatabase || ""}`,
+            `IcebergDatabase=${services.icebergDatabase || ""}`,
         ];
 
         const parametersArg = parameters.map(p => `--parameters ${p}`).join(" ");

--- a/bin/commands/deploy.ts
+++ b/bin/commands/deploy.ts
@@ -635,7 +635,9 @@ export async function deploy(
     const ecrRepository = config.deployment.ecrRepository || "quiltdata/benchling";
     const ecrImageUri = `${ecrAccount}.dkr.ecr.${ecrRegion}.amazonaws.com/${ecrRepository}:${options.imageTag}`;
     const packagePrefix = config.packages.prefix || "benchling";
-    const eventSummary = `bucket=${config.packages.bucket}, prefix=${packagePrefix}/ type=package-revision source=com.quiltdata bus=default`;
+    const eventSummary = config.packages.bucket
+        ? `bucket=${config.packages.bucket}, prefix=${packagePrefix}/ type=package-revision source=com.quiltdata bus=default`
+        : `bucketless, prefix=${packagePrefix}/ type=package-revision source=com.quiltdata bus=default`;
 
     // Display deployment plan
     console.log();
@@ -791,7 +793,7 @@ export async function deploy(
             // Legacy parameters
             `BenchlingSecretARN=${benchlingSecret}`,
             `ImageTag=${options.imageTag}`,
-            `PackageBucket=${config.packages.bucket}`,
+            `PackageBucket=${config.packages.bucket || ""}`,
             `QuiltDatabase=${config.quilt.database || ""}`,  // IAM permissions only (same value as AthenaUserDatabase)
             `LogLevel=${config.logging?.level || "INFO"}`,
         ];

--- a/bin/commands/infer-quilt-config.ts
+++ b/bin/commands/infer-quilt-config.ts
@@ -43,6 +43,7 @@ interface QuiltStackInfo {
     athenaUserWorkgroup?: string;
     bucketWritePolicyArn?: string;
     athenaUserPolicyArn?: string;
+    icebergDatabase?: string;
 }
 
 /**
@@ -60,6 +61,7 @@ interface InferenceResult {
     athenaUserWorkgroup?: string;
     bucketWritePolicyArn?: string;
     athenaUserPolicyArn?: string;
+    icebergDatabase?: string;
     source: string;
 }
 
@@ -168,8 +170,10 @@ async function findQuiltStacks(region: string = "us-east-1", profile?: string, t
 
                     if (key === "QuiltWebHost") {
                         stackInfo.catalogUrl = value;
-                    } else if (key === "UserAthenaDatabaseName" || key.includes("Database")) {
+                    } else if (key === "UserAthenaDatabaseName") {
                         stackInfo.database = value;
+                    } else if (key === "IcebergDatabase" || key === "IcebergDatabaseName") {
+                        stackInfo.icebergDatabase = value;
                     } else if (key.includes("Queue")) {
                         if (isQueueUrl(value)) {
                             stackInfo.queueUrl = value;
@@ -501,6 +505,10 @@ export async function inferQuiltConfig(options: {
     if (selectedStack.athenaUserPolicyArn) {
         result.athenaUserPolicyArn = selectedStack.athenaUserPolicyArn;
     }
+    if (selectedStack.icebergDatabase) {
+        result.icebergDatabase = selectedStack.icebergDatabase;
+        console.log(`✓ IcebergDatabase discovered: ${selectedStack.icebergDatabase}`);
+    }
     // NEW: Add IAM managed policy ARNs to result
     // IAM managed policies for S3 and Athena access (attached directly to task role)
     if (selectedStack.bucketWritePolicyArn) {
@@ -555,6 +563,7 @@ async function main(): Promise<void> {
     if (result.queueUrl) console.log(`Queue URL: ${result.queueUrl}`);
     if (result.bucketWritePolicyArn) console.log(`Bucket Write Policy ARN: ${result.bucketWritePolicyArn}`);
     if (result.athenaUserPolicyArn) console.log(`Athena User Policy ARN: ${result.athenaUserPolicyArn}`);
+    if (result.icebergDatabase) console.log(`Iceberg Database: ${result.icebergDatabase}`);
 }
 
 // Run main if executed directly

--- a/bin/commands/sync-secrets.ts
+++ b/bin/commands/sync-secrets.ts
@@ -296,7 +296,7 @@ function buildSecretValue(config: ProfileConfig, clientSecret: string): string {
         client_id: config.benchling.clientId,
         client_secret: clientSecret,
         app_definition_id: config.benchling.appDefinitionId,
-        user_bucket: config.packages.bucket,
+        ...(config.packages.bucket ? { user_bucket: config.packages.bucket } : {}),
         pkg_prefix: config.packages.prefix,
         pkg_key: config.packages.metadataKey,
         ...(config.packages.workflow ? { workflow: config.packages.workflow } : {}),

--- a/bin/commands/sync-secrets.ts
+++ b/bin/commands/sync-secrets.ts
@@ -309,6 +309,27 @@ function buildSecretValue(config: ProfileConfig, clientSecret: string): string {
 }
 
 /**
+ * Redacts sensitive fields from a secret value JSON string for safe display.
+ *
+ * Never expose the plaintext client secret in console output (e.g. dry-run).
+ *
+ * @param secretValue - Secret value as JSON string (from buildSecretValue)
+ * @returns JSON string with client_secret masked
+ */
+function maskSecretValue(secretValue: string): string {
+    try {
+        const parsed = JSON.parse(secretValue) as Record<string, unknown>;
+        if (typeof parsed.client_secret === "string" && parsed.client_secret.length > 0) {
+            parsed.client_secret = "***REDACTED***";
+        }
+        return JSON.stringify(parsed, null, 2);
+    } catch {
+        // If parsing fails, do not risk leaking the raw value
+        return "<unable to render secret value>";
+    }
+}
+
+/**
  * Syncs configuration to AWS Secrets Manager
  *
  * Mode-aware behavior (B7):
@@ -389,7 +410,7 @@ export async function syncSecretsToAWS(options: SyncSecretsOptions): Promise<Syn
         console.log("\n=== DRY RUN MODE ===");
         console.log(`Mode: ${isIntegratedMode ? "Integrated" : "Standalone"}`);
         console.log(`Would sync secret: ${secretName}`);
-        console.log(`Secret value:\n${secretValue}`);
+        console.log(`Secret value:\n${maskSecretValue(secretValue)}`);
         return results;
     }
 

--- a/bin/commands/validate.ts
+++ b/bin/commands/validate.ts
@@ -60,7 +60,7 @@ export async function validateCommand(options: ValidateOptions): Promise<void> {
         console.log();
 
         console.log(chalk.bold("Packages:"));
-        console.log(`  Bucket: ${config.packages.bucket}`);
+        console.log(`  Bucket: ${config.packages.bucket || "(bucketless mode)"}`);
         console.log(`  Prefix: ${config.packages.prefix}`);
         console.log(`  Metadata Key: ${config.packages.metadataKey}`);
         console.log();

--- a/bin/xdg-launch.ts
+++ b/bin/xdg-launch.ts
@@ -14,6 +14,8 @@
 import { spawn } from "child_process";
 import { resolve } from "path";
 import { existsSync } from "fs";
+import { config as dotenvConfig } from "dotenv";
+import { expand as dotenvExpand } from "dotenv-expand";
 import { XDGConfig } from "../lib/xdg-config";
 import { ProfileConfig } from "../lib/types/config";
 
@@ -142,6 +144,20 @@ function loadProfile(profileName: string): ProfileConfig {
     }
 
     return xdg.readProfile(profileName);
+}
+
+/**
+ * Load repository-local .env for local launch/test convenience.
+ *
+ * Profile config remains authoritative for managed deployment values; .env
+ * only fills process environment values that are not represented in profiles,
+ * such as local-only queue URLs.
+ */
+function loadLocalEnv(): void {
+    const envPath = resolve(__dirname, "..", ".env");
+    if (existsSync(envPath)) {
+        dotenvExpand(dotenvConfig({ path: envPath }));
+    }
 }
 
 /**
@@ -767,6 +783,9 @@ async function launchDockerDev(envVars: EnvVars, options: LaunchOptions): Promis
  */
 async function main(): Promise<void> {
     try {
+        // Load local .env before building process-backed environment variables.
+        loadLocalEnv();
+
         // Parse command-line arguments
         const options = parseArguments(process.argv);
 

--- a/bin/xdg-launch.ts
+++ b/bin/xdg-launch.ts
@@ -217,6 +217,7 @@ function buildEnvVars(config: ProfileConfig, mode: LaunchMode, options: LaunchOp
         QUILT_WEB_HOST: config.quilt.catalog,
         ATHENA_USER_DATABASE: config.quilt.database,
         ATHENA_USER_WORKGROUP: config.quilt.athenaUserWorkgroup || "primary",
+        QUILT_ICEBERG_DATABASE: config.quilt.icebergDatabase || "",
         PACKAGER_SQS_URL: config.quilt.queueUrl,
 
         // IAM Policy ARNs for ECS task role (attached directly, no role assumption needed)
@@ -352,7 +353,7 @@ function spawnDockerCompose(
     stdio: "inherit" | "pipe" = "inherit",
 ): ReturnType<typeof spawn> {
     // Debug: Log key environment variables being passed
-    const keyVars = ["QUILT_WEB_HOST", "ATHENA_USER_DATABASE", "PACKAGER_SQS_URL", "BenchlingSecret"];
+    const keyVars = ["QUILT_WEB_HOST", "ATHENA_USER_DATABASE", "QUILT_ICEBERG_DATABASE", "PACKAGER_SQS_URL", "BenchlingSecret"];
     const debug = process.env.DEBUG_XDG === "true";
     if (debug) {
         console.log("DEBUG: Spawning docker-compose with environment:");

--- a/docker/app-manifest.yaml
+++ b/docker/app-manifest.yaml
@@ -2,7 +2,7 @@ manifestVersion: 1
 info:
   name: nightly-quilttest-com
   description: Packaging Benchling Notebooks as Quilt packages
-  version: 0.18.0
+  version: 0.19.0
 features:
   - name: Quilt Connector
     id: quilt_entry

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - ATHENA_USER_DATABASE=${ATHENA_USER_DATABASE}
       - ATHENA_USER_WORKGROUP=${ATHENA_USER_WORKGROUP:-primary}
       - PACKAGER_SQS_URL=${PACKAGER_SQS_URL}
+      - PACKAGING_REQUEST_QUEUE_URL=${PACKAGING_REQUEST_QUEUE_URL}
 
       # Benchling Configuration (credentials from Secrets Manager)
       - BenchlingSecret=${BenchlingSecret}
@@ -62,6 +63,7 @@ services:
       - ATHENA_USER_DATABASE=${ATHENA_USER_DATABASE}
       - ATHENA_USER_WORKGROUP=${ATHENA_USER_WORKGROUP:-primary}
       - PACKAGER_SQS_URL=${PACKAGER_SQS_URL}
+      - PACKAGING_REQUEST_QUEUE_URL=${PACKAGING_REQUEST_QUEUE_URL}
 
       # Benchling Configuration (credentials from Secrets Manager)
       - BenchlingSecret=${BenchlingSecret}

--- a/docker/pyproject.toml
+++ b/docker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "benchling-quilt-integration"
-version = "0.18.0"
+version = "0.19.0"
 description = "Benchling-Quilt Integration Webhook Service"
 license = {text = "Apache-2.0"}
 authors = [

--- a/docker/scripts/quilt_search_probe.py
+++ b/docker/scripts/quilt_search_probe.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Probe Quilt package search for Benchling linkage metadata.
+
+This script intentionally lives outside the service path. It validates whether
+``quilt3.search`` can find linked packages across all accessible buckets, and
+whether bucket-scoped search returns the same package when a bucket is known.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+import quilt3
+from quilt3.util import QuiltException
+
+
+def _normalize_catalog(catalog: str) -> str:
+    catalog = catalog.strip()
+    if not catalog:
+        raise ValueError("catalog is required")
+    if not catalog.startswith(("http://", "https://")):
+        catalog = f"https://{catalog}"
+    return catalog.rstrip("/")
+
+
+def _summarize_hit(hit: dict[str, Any]) -> dict[str, Any]:
+    source = hit.get("_source", hit)
+    metadata = source.get("metadata") or source.get("mnfst_metadata") or {}
+    return {
+        "index": hit.get("_index"),
+        "id": hit.get("_id"),
+        "score": hit.get("_score"),
+        "handle": source.get("handle") or hit.get("handle"),
+        "registry": source.get("registry") or source.get("bucket") or hit.get("registry"),
+        "metadata": {k: metadata.get(k) for k in sorted(metadata) if k in {"entry_id", "display_id", "experiment_id", "package_name"}},
+    }
+
+
+def _run_query(label: str, query: str | dict[str, Any], limit: int) -> list[dict[str, Any]]:
+    print(f"\n## {label}")
+    print(f"query: {json.dumps(query) if isinstance(query, dict) else query}")
+    try:
+        hits = quilt3.search(query, limit=limit)
+    except QuiltException as exc:
+        print(f"error: {exc}")
+        return []
+    print(f"hits: {len(hits)}")
+    for hit in hits[: min(limit, 5)]:
+        print(json.dumps(_summarize_hit(hit), indent=2, sort_keys=True))
+    return hits
+
+
+def _bucket_uri(bucket: str) -> str:
+    if bucket.startswith("s3://"):
+        return bucket
+    return f"s3://{bucket}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", default=os.getenv("QUILT_WEB_HOST", "nightly.quilttest.com"))
+    parser.add_argument("--key", default=os.getenv("PKG_KEY", "experiment_id"))
+    parser.add_argument("--value", default=os.getenv("PKG_VALUE", "EXP26000012"))
+    parser.add_argument("--bucket", default=os.getenv("QUILT_USER_BUCKET", ""))
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument(
+        "--refresh-token-env",
+        default="QUILT_REFRESH_TOKEN",
+        help="Environment variable containing a Quilt refresh token. If absent, existing quilt3 auth is used.",
+    )
+    args = parser.parse_args()
+
+    catalog = _normalize_catalog(args.catalog)
+    print(f"catalog: {catalog}")
+    print(f"metadata: {args.key}={args.value}")
+    print(f"bucket: {args.bucket or '<all accessible buckets>'}")
+
+    quilt3.config(catalog)
+
+    refresh_token = os.getenv(args.refresh_token_env, "").strip()
+    if refresh_token:
+        print(f"auth: logging in with refresh token from ${args.refresh_token_env}")
+        quilt3.login_with_token(refresh_token)
+    else:
+        print("auth: using existing quilt3 auth, if any")
+
+    print(f"logged_in: {quilt3.logged_in()}")
+
+    query_string = f'{args.key}:"{args.value}"'
+    _run_query("global query_string search", query_string, args.limit)
+
+    query_dsl = {
+        "query": {
+            "bool": {
+                "should": [
+                    {"term": {f"metadata.{args.key}.keyword": args.value}},
+                    {"term": {f"mnfst_metadata.{args.key}.keyword": args.value}},
+                    {"query_string": {"query": query_string}},
+                ],
+                "minimum_should_match": 1,
+            }
+        }
+    }
+    _run_query("global DSL search", query_dsl, args.limit)
+
+    if args.bucket:
+        print("\n## bucket-scoped search")
+        bucket = quilt3.Bucket(_bucket_uri(args.bucket))
+        try:
+            hits = bucket.search(query_string, limit=args.limit)
+        except QuiltException as exc:
+            print(f"error: {exc}")
+            return
+        print(f"hits: {len(hits)}")
+        for hit in hits[: min(args.limit, 5)]:
+            print(json.dumps(_summarize_hit(hit), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/scripts/quilt_search_probe.py
+++ b/docker/scripts/quilt_search_probe.py
@@ -35,7 +35,11 @@ def _summarize_hit(hit: dict[str, Any]) -> dict[str, Any]:
         "score": hit.get("_score"),
         "handle": source.get("handle") or hit.get("handle"),
         "registry": source.get("registry") or source.get("bucket") or hit.get("registry"),
-        "metadata": {k: metadata.get(k) for k in sorted(metadata) if k in {"entry_id", "display_id", "experiment_id", "package_name"}},
+        "metadata": {
+            k: metadata.get(k)
+            for k in sorted(metadata)
+            if k in {"entry_id", "display_id", "experiment_id", "package_name"}
+        },
     }
 
 
@@ -83,7 +87,7 @@ def main() -> None:
     refresh_token = os.getenv(args.refresh_token_env, "").strip()
     if refresh_token:
         print(f"auth: logging in with refresh token from ${args.refresh_token_env}")
-        quilt3.login_with_token(refresh_token)
+        quilt3.login_with_token(refresh_token)  # type: ignore[attr-defined]
     else:
         print("auth: using existing quilt3 auth, if any")
 

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -710,6 +710,24 @@ def create_app() -> FastAPI:
                 error=str(exc),
             )
 
+    def _send_bucketless_final_canvas_best_effort(payload: Payload) -> None:
+        """Start the final bucketless Canvas render after the quick acknowledgment.
+
+        Bucketless mode has no packaging workflow to produce a later package
+        revision event, so the Canvas handler must render the final linked-package
+        view itself. Run it asynchronously to keep the webhook response fast.
+        """
+        if not payload.canvas_id or benchling is None or config is None:
+            return
+        try:
+            CanvasManager(benchling, config, payload).handle_async()
+        except Exception as exc:
+            logger.warning(
+                "Failed to start final bucketless canvas update",
+                canvas_id=payload.canvas_id,
+                error=str(exc),
+            )
+
     def _bucketless_response(payload: Payload, message: str) -> JSONResponse:
         logger.info(
             "Bucketless mode skipped package creation",
@@ -756,6 +774,7 @@ def create_app() -> FastAPI:
                 )
                 _send_updating_canvas_best_effort(payload)
                 if not config.s3_bucket_name:
+                    _send_bucketless_final_canvas_best_effort(payload)
                     return _bucketless_response(
                         payload,
                         "Bucketless mode does not create a default package for canvas events.",
@@ -927,6 +946,7 @@ def create_app() -> FastAPI:
 
             _send_updating_canvas_best_effort(payload)
             if not config.s3_bucket_name:
+                _send_bucketless_final_canvas_best_effort(payload)
                 return _bucketless_response(
                     payload,
                     "Bucketless mode does not create a default package for canvas initialization.",

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -1202,6 +1202,7 @@ def create_app() -> FastAPI:
         if config.s3_bucket_name:
             # A bucket was configured after this (bucketless) canvas was drawn:
             # initiate default package creation instead of re-rendering bucketless.
+            assert entry_packager is not None
             assert packaging_queue_url is not None, "packaging_queue_url must be set when not in degraded mode"
             sqs_message_id = publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
             CanvasManager(benchling, config, payload).handle_async()

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -710,6 +710,23 @@ def create_app() -> FastAPI:
                 error=str(exc),
             )
 
+    def _bucketless_response(payload: Payload, message: str) -> JSONResponse:
+        logger.info(
+            "Bucketless mode skipped package creation",
+            entry_id=payload.entry_id,
+            event_type=payload.event_type,
+            canvas_id=payload.canvas_id,
+        )
+        return JSONResponse(
+            {
+                "entry_id": payload.entry_id,
+                "status": "SKIPPED",
+                "mode": "bucketless",
+                "message": message,
+            },
+            status_code=202,
+        )
+
     async def _handle_event_impl(request: Request, _verified: None = None):
         """Shared event webhook handling implementation."""
         try:
@@ -738,6 +755,11 @@ def create_app() -> FastAPI:
                     canvas_id=payload.canvas_id,
                 )
                 _send_updating_canvas_best_effort(payload)
+                if not config.s3_bucket_name:
+                    return _bucketless_response(
+                        payload,
+                        "Bucketless mode does not create a default package for canvas events.",
+                    )
                 publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
 
                 logger.info("Canvas update initiated from /event endpoint", canvas_id=payload.canvas_id)
@@ -757,6 +779,12 @@ def create_app() -> FastAPI:
                     "status": "ignored",
                     "message": f"Event type {payload.event_type} not processed",
                 }
+
+            if not config.s3_bucket_name:
+                return _bucketless_response(
+                    payload,
+                    "Bucketless mode does not create a default package for entry events.",
+                )
 
             publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
 
@@ -898,6 +926,11 @@ def create_app() -> FastAPI:
                 logger.warning("Unknown button action from /canvas", button_id=button_id)
 
             _send_updating_canvas_best_effort(payload)
+            if not config.s3_bucket_name:
+                return _bucketless_response(
+                    payload,
+                    "Bucketless mode does not create a default package for canvas initialization.",
+                )
             sqs_message_id = publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
 
             logger.info(
@@ -937,6 +970,11 @@ def create_app() -> FastAPI:
         from .pagination import parse_button_id
 
         try:
+            if not config.s3_bucket_name:
+                return _bucketless_response(
+                    payload,
+                    "Bucketless mode has no default package to browse.",
+                )
             _, entry_id, page_state = parse_button_id(button_id)
 
             page_number = page_state.page_number if page_state else 0
@@ -965,10 +1003,12 @@ def create_app() -> FastAPI:
 
     def handle_browse_linked(payload, button_id, benchling, config):
         """Handle Browse Linked Package button click."""
-        from .pagination import parse_browse_linked_button_id
+        from .pagination import parse_browse_linked_button_id_with_bucket
 
         try:
-            entry_id, package_name, page_number, page_size = parse_browse_linked_button_id(button_id)
+            entry_id, package_name, bucket_name, page_number, page_size = parse_browse_linked_button_id_with_bucket(
+                button_id
+            )
         except ValueError as e:
             logger.error("Invalid browse-linked button ID", button_id=button_id, error=str(e))
             return JSONResponse({"error": "Invalid button ID"}, status_code=400)
@@ -977,6 +1017,7 @@ def create_app() -> FastAPI:
             "Browse linked package requested",
             entry_id=entry_id,
             package_name=package_name,
+            bucket=bucket_name,
             page=page_number,
             size=page_size,
         )
@@ -984,7 +1025,7 @@ def create_app() -> FastAPI:
         canvas_manager = CanvasManager(benchling, config, payload)
 
         try:
-            blocks = canvas_manager.get_package_browser_blocks(page_number, page_size, package_name)
+            blocks = canvas_manager.get_package_browser_blocks(page_number, page_size, package_name, bucket_name)
         except Exception as e:
             logger.error(
                 "Failed to get package browser blocks",
@@ -1001,6 +1042,7 @@ def create_app() -> FastAPI:
                     "Canvas updated with linked package browser",
                     entry_id=entry_id,
                     package_name=package_name,
+                    bucket=bucket_name,
                     page=page_number,
                 )
             except Exception as e:
@@ -1023,6 +1065,11 @@ def create_app() -> FastAPI:
         from .pagination import parse_button_id
 
         try:
+            if not config.s3_bucket_name:
+                return _bucketless_response(
+                    payload,
+                    "Bucketless mode has no default package pages to browse.",
+                )
             action, entry_id, page_state = parse_button_id(button_id)
 
             page_number = page_state.page_number if page_state else 0
@@ -1053,15 +1100,18 @@ def create_app() -> FastAPI:
 
     def handle_page_navigation_linked(payload, button_id, benchling, config):
         """Handle Next/Previous page button clicks for linked packages."""
-        from .pagination import parse_browse_linked_button_id
+        from .pagination import parse_browse_linked_button_id_with_bucket
 
         try:
-            entry_id, package_name, page_number, page_size = parse_browse_linked_button_id(button_id)
+            entry_id, package_name, bucket_name, page_number, page_size = parse_browse_linked_button_id_with_bucket(
+                button_id
+            )
 
             logger.info(
                 "Linked package page navigation",
                 entry_id=entry_id,
                 package_name=package_name,
+                bucket=bucket_name,
                 page=page_number,
             )
 
@@ -1069,13 +1119,16 @@ def create_app() -> FastAPI:
 
             def async_update():
                 try:
-                    blocks = canvas_manager.get_package_browser_blocks(page_number, page_size, package_name)
+                    blocks = canvas_manager.get_package_browser_blocks(
+                        page_number, page_size, package_name, bucket_name
+                    )
                     canvas_update = AppCanvasUpdate(blocks=blocks, enabled=True)  # type: ignore
                     benchling.apps.update_canvas(canvas_id=payload.canvas_id, canvas=canvas_update)
                     logger.info(
                         "Canvas updated with linked package page",
                         canvas_id=payload.canvas_id,
                         package_name=package_name,
+                        bucket=bucket_name,
                         page=page_number,
                     )
                 except Exception as e:
@@ -1115,6 +1168,11 @@ def create_app() -> FastAPI:
         from .pagination import parse_button_id
 
         try:
+            if not config.s3_bucket_name:
+                return _bucketless_response(
+                    payload,
+                    "Bucketless mode has no default package metadata to view.",
+                )
             _, entry_id, page_state = parse_button_id(button_id)
 
             page_number = page_state.page_number if page_state else 0
@@ -1143,24 +1201,32 @@ def create_app() -> FastAPI:
 
     def handle_view_metadata_linked(payload, button_id, benchling, config):
         """Handle View Metadata button click for linked packages."""
-        from .pagination import parse_browse_linked_button_id
+        from .pagination import parse_browse_linked_button_id_with_bucket
 
         try:
-            entry_id, package_name, page_number, page_size = parse_browse_linked_button_id(button_id)
+            entry_id, package_name, bucket_name, page_number, page_size = parse_browse_linked_button_id_with_bucket(
+                button_id
+            )
 
-            logger.info("Metadata view requested for linked package", entry_id=entry_id, package_name=package_name)
+            logger.info(
+                "Metadata view requested for linked package",
+                entry_id=entry_id,
+                package_name=package_name,
+                bucket=bucket_name,
+            )
 
             canvas_manager = CanvasManager(benchling, config, payload)
 
             def async_update():
                 try:
-                    blocks = canvas_manager.get_metadata_blocks(page_number, page_size, package_name)
+                    blocks = canvas_manager.get_metadata_blocks(page_number, page_size, package_name, bucket_name)
                     canvas_update = AppCanvasUpdate(blocks=blocks, enabled=True)  # type: ignore
                     benchling.apps.update_canvas(canvas_id=payload.canvas_id, canvas=canvas_update)
                     logger.info(
                         "Canvas updated with linked package metadata view",
                         canvas_id=payload.canvas_id,
                         package_name=package_name,
+                        bucket=bucket_name,
                     )
                 except Exception as e:
                     logger.error("Failed to update canvas with linked package metadata", error=str(e), exc_info=True)
@@ -1177,6 +1243,11 @@ def create_app() -> FastAPI:
         """Handle Update Package button click (existing functionality)."""
         logger.info("Update package requested", entry_id=payload.entry_id)
         assert packaging_queue_url is not None, "packaging_queue_url must be set when not in degraded mode"
+        if not config.s3_bucket_name:
+            return _bucketless_response(
+                payload,
+                "Bucketless mode does not create a default package from the update action.",
+            )
 
         sqs_message_id = publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
 

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -939,6 +939,8 @@ def create_app() -> FastAPI:
                     return handle_view_metadata_linked(payload, button_id, benchling, config)
                 if button_id.startswith("view-metadata-"):
                     return handle_view_metadata(payload, button_id, benchling, config)
+                if button_id.startswith("refresh-canvas-"):
+                    return handle_refresh_canvas(payload, button_id, benchling, config)
                 if button_id.startswith("update-package-"):
                     return handle_update_package(payload, entry_packager, benchling, config)
 
@@ -1166,7 +1168,7 @@ def create_app() -> FastAPI:
 
     def handle_back_to_main(payload, button_id, benchling, config):
         """Handle Back to Package button click."""
-        logger.info("Back to package requested", entry_id=payload.entry_id)
+        logger.info("Back to main canvas requested", entry_id=payload.entry_id)
 
         canvas_manager = CanvasManager(benchling, config, payload)
 
@@ -1175,13 +1177,27 @@ def create_app() -> FastAPI:
                 blocks = canvas_manager._make_blocks()
                 canvas_update = AppCanvasUpdate(blocks=blocks, enabled=True)  # type: ignore
                 benchling.apps.update_canvas(canvas_id=payload.canvas_id, canvas=canvas_update)
-                logger.info("Canvas updated with main package view", canvas_id=payload.canvas_id)
+                logger.info("Canvas updated with main view", canvas_id=payload.canvas_id)
             except Exception as e:
-                logger.error("Failed to return to main package view", error=str(e), exc_info=True)
+                logger.error("Failed to return to main canvas view", error=str(e), exc_info=True)
 
         threading.Thread(target=async_update, daemon=True).start()
 
-        return JSONResponse({"status": "ACCEPTED", "message": "Returning to package view..."}, status_code=202)
+        return JSONResponse({"status": "ACCEPTED", "message": "Returning to canvas..."}, status_code=202)
+
+    def handle_refresh_canvas(payload, button_id, benchling, config):
+        """Handle bucketless Refresh Canvas button click."""
+        logger.info("Refresh canvas requested", entry_id=payload.entry_id, button_id=button_id)
+
+        if config.s3_bucket_name:
+            return JSONResponse(
+                {"status": "ignored", "message": "Refresh Canvas is only available in bucketless mode."},
+                status_code=400,
+            )
+
+        _send_updating_canvas_best_effort(payload)
+        _send_bucketless_final_canvas_best_effort(payload)
+        return JSONResponse({"status": "ACCEPTED", "message": "Refreshing canvas..."}, status_code=202)
 
     def handle_view_metadata(payload, button_id, benchling, config):
         """Handle View Metadata button click for primary package."""

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -1186,16 +1186,40 @@ def create_app() -> FastAPI:
         return JSONResponse({"status": "ACCEPTED", "message": "Returning to canvas..."}, status_code=202)
 
     def handle_refresh_canvas(payload, button_id, benchling, config):
-        """Handle bucketless Refresh Canvas button click."""
+        """Handle Refresh Canvas button click.
+
+        The button is rendered on the bucketless canvas. Re-check the current
+        config: if a default package bucket has since been configured (e.g. the
+        webhook was reconfigured and restarted with a bucket after this canvas
+        was drawn), transition to the bucketed flow — enqueue a packaging
+        request to create the default package and render the standard canvas.
+        Otherwise, re-run the bucketless linked-package lookup.
+        """
         logger.info("Refresh canvas requested", entry_id=payload.entry_id, button_id=button_id)
 
+        _send_updating_canvas_best_effort(payload)
+
         if config.s3_bucket_name:
+            # A bucket was configured after this (bucketless) canvas was drawn:
+            # initiate default package creation instead of re-rendering bucketless.
+            assert packaging_queue_url is not None, "packaging_queue_url must be set when not in degraded mode"
+            sqs_message_id = publish_packaging_request(entry_packager.sqs_client, packaging_queue_url, payload)
+            CanvasManager(benchling, config, payload).handle_async()
+            logger.info(
+                "Refresh canvas initiated default package creation",
+                entry_id=payload.entry_id,
+                canvas_id=payload.canvas_id,
+                sqs_message_id=sqs_message_id,
+            )
             return JSONResponse(
-                {"status": "ignored", "message": "Refresh Canvas is only available in bucketless mode."},
-                status_code=400,
+                {
+                    "status": "ACCEPTED",
+                    "message": "Creating default package...",
+                    "sqs_message_id": sqs_message_id,
+                },
+                status_code=202,
             )
 
-        _send_updating_canvas_best_effort(payload)
         _send_bucketless_final_canvas_best_effort(payload)
         return JSONResponse({"status": "ACCEPTED", "message": "Refreshing canvas..."}, status_code=202)
 

--- a/docker/src/canvas.py
+++ b/docker/src/canvas.py
@@ -18,7 +18,7 @@ from .config import Config
 from .package_files import PackageFile, PackageFileFetcher
 from .package_query import PackageQuery
 from .packages import Package
-from .pagination import PageState, paginate_items
+from .pagination import PageState, encode_bucket_name, encode_package_name, paginate_items
 from .payload import Payload
 from .version import __version__
 
@@ -220,7 +220,7 @@ class CanvasManager:
             content = (
                 f"## Benchling Entry\n\n"
                 f"**Entry**: {self.entry.display_id}\n\n"
-                "No default package bucket is configured. Linked packages are shown when found in accessible buckets.\n"
+                "No default package bucket is configured. Use **Refresh Canvas** to search accessible buckets for linked packages.\n"
             )
 
         # Linked packages
@@ -237,7 +237,10 @@ class CanvasManager:
             # Store linked packages as instance variable
             self._linked_packages = linked_packages
 
-            content += fmt.format_linked_packages(linked_packages)
+            if linked_packages:
+                content += fmt.format_linked_packages(linked_packages)
+            elif not self.config.s3_bucket_name:
+                content += "\n### Linked Packages\n\nNo linked packages found in accessible buckets.\n"
 
         except Exception as e:
             error_msg = f"Failed to search for linked packages: {str(e)}"
@@ -290,8 +293,9 @@ class CanvasManager:
         result = [
             *blocks.create_main_navigation_buttons(
                 self.entry_id,
-                update_enabled=not is_updating and bool(self.config.s3_bucket_name),
+                update_enabled=not is_updating,
                 browse_enabled=bool(self.config.s3_bucket_name),
+                bucketless=not bool(self.config.s3_bucket_name),
             ),
             markdown_block,
         ]
@@ -335,7 +339,7 @@ class CanvasManager:
             logger.info(
                 "Updating Canvas",
                 canvas_id=self.canvas_id,
-                package_name=self.package_name,
+                package_name=self.package_name if self.config.s3_bucket_name else None,
                 blocks_count=len(blocks),
             )
 
@@ -479,17 +483,30 @@ class CanvasManager:
         if context == "main":
             return blocks.create_main_navigation_buttons(
                 self.entry_id,
-                update_enabled=bool(self.config.s3_bucket_name),
+                update_enabled=True,
                 browse_enabled=bool(self.config.s3_bucket_name),
+                bucketless=not bool(self.config.s3_bucket_name),
             )
         if context == "browser":
             if page_state is None:
                 raise ValueError("page_state required for browser context")
-            return blocks.create_browser_navigation_buttons(self.entry_id, page_state, package_name, bucket_name)
+            return blocks.create_browser_navigation_buttons(
+                self.entry_id,
+                page_state,
+                package_name,
+                bucket_name,
+                bucketless=not bool(self.config.s3_bucket_name),
+            )
         if context == "metadata":
             if page_state is None:
                 raise ValueError("page_state required for metadata context")
-            return blocks.create_metadata_navigation_buttons(self.entry_id, page_state, package_name, bucket_name)
+            return blocks.create_metadata_navigation_buttons(
+                self.entry_id,
+                page_state,
+                package_name,
+                bucket_name,
+                bucketless=not bool(self.config.s3_bucket_name),
+            )
         raise ValueError(f"Unknown context: {context}")
 
     def get_package_browser_blocks(
@@ -566,21 +583,43 @@ class CanvasManager:
             error_msg = str(e).lower()
             if "does not exist" in error_msg or "not found" in error_msg or "no such package" in error_msg:
                 # Package doesn't exist yet
-                markdown = fmt.format_package_not_found(browsing_package_name)
+                markdown = fmt.format_package_not_found(
+                    browsing_package_name,
+                    can_create=bool(self.config.s3_bucket_name),
+                )
+                if self.config.s3_bucket_name:
+                    actions = [
+                        blocks.create_button_block(f"update-package-{self.entry_id}", "Update Package"),
+                        blocks.create_button_block(f"back-to-package-{self.entry_id}", "Back to Package"),
+                    ]
+                else:
+                    actions = [
+                        blocks.create_button_block(f"refresh-canvas-{self.entry_id}", "Refresh Canvas"),
+                        blocks.create_button_block(f"back-to-package-{self.entry_id}", "Back to Entry"),
+                    ]
 
                 return [
                     blocks.create_markdown_block(markdown, "md-no-package"),
-                    blocks.create_button_block(f"update-package-{self.entry_id}", "Update Package"),
-                    blocks.create_button_block(f"back-to-package-{self.entry_id}", "Back to Package"),
+                    *actions,
                 ]
 
             # Other error (API failure, network error, etc.)
             markdown = fmt.format_error_loading_files(browsing_package_name, str(e))
+            retry_id = f"browse-files-{self.entry_id}-p{page_number}-s{page_size}"
+            if package_name:
+                bucket_part = f"-bucket-{encode_bucket_name(bucket_name)}" if bucket_name else ""
+                retry_id = (
+                    f"browse-linked-{self.entry_id}-pkg-{encode_package_name(package_name)}"
+                    f"{bucket_part}-p{page_number}-s{page_size}"
+                )
 
             return [
                 blocks.create_markdown_block(markdown, "md-error"),
-                blocks.create_button_block(f"browse-files-{self.entry_id}-p{page_number}-s{page_size}", "Retry"),
-                blocks.create_button_block(f"back-to-package-{self.entry_id}", "Back to Package"),
+                blocks.create_button_block(retry_id, "Retry"),
+                blocks.create_button_block(
+                    f"back-to-package-{self.entry_id}",
+                    "Back to Entry" if not self.config.s3_bucket_name else "Back to Package",
+                ),
             ]
 
     def get_package_browser_response(
@@ -661,7 +700,10 @@ class CanvasManager:
 
             return [
                 blocks.create_markdown_block(markdown, "md-error"),
-                blocks.create_button_block(f"back-to-package-{self.entry_id}", "Back to Package"),
+                blocks.create_button_block(
+                    f"back-to-package-{self.entry_id}",
+                    "Back to Entry" if not self.config.s3_bucket_name else "Back to Package",
+                ),
             ]
 
     def get_metadata_response(

--- a/docker/src/canvas.py
+++ b/docker/src/canvas.py
@@ -64,6 +64,7 @@ class CanvasManager:
         self._package = None
         self._errors: List[str] = []  # Track errors to display in notification section
         self._linked_packages: List[Package] = []  # Track linked packages for use in blocks
+        self._package_file_fetcher_injected = package_file_fetcher is not None
 
         # Dependency injection with fallback to default instances
 
@@ -104,6 +105,8 @@ class CanvasManager:
     def package(self) -> Package:
         """Get Package instance for this entry."""
         if self._package is None:
+            if not self.config.s3_bucket_name:
+                raise ValueError("No configured package bucket in bucketless mode")
             # Ensure display_id is set on payload for package naming
             if not self.payload.display_id:
                 self.payload.set_display_id(self.entry.display_id)
@@ -157,6 +160,18 @@ class CanvasManager:
 
         return uri
 
+    def _file_fetcher_for_bucket(self, bucket_name: Optional[str]) -> PackageFileFetcher:
+        if self._package_file_fetcher_injected:
+            return self._package_file_fetcher
+        if not bucket_name or bucket_name == self._package_file_fetcher.bucket:
+            return self._package_file_fetcher
+        return PackageFileFetcher(
+            catalog_url=self.config.quilt_catalog,
+            bucket=bucket_name,
+            role_arn=self.config.quilt_write_role_arn,
+            region=self.config.aws_region,
+        )
+
     def sync_uri(self, path: Optional[str] = None, version: Optional[str] = None) -> str:
         """Generate URL-encoded redirect URI for the package.
 
@@ -194,13 +209,19 @@ class CanvasManager:
         Returns:
             Formatted markdown string with package links
         """
-        # Primary package header
-        content = fmt.format_package_header(
-            package_name=self.package_name,
-            display_id=self.entry.display_id,
-            catalog_url=self.catalog_url,
-            sync_url=self.sync_uri(),
-        )
+        if self.config.s3_bucket_name:
+            content = fmt.format_package_header(
+                package_name=self.package_name,
+                display_id=self.entry.display_id,
+                catalog_url=self.catalog_url,
+                sync_url=self.sync_uri(),
+            )
+        else:
+            content = (
+                f"## Benchling Entry\n\n"
+                f"**Entry**: {self.entry.display_id}\n\n"
+                "No default package bucket is configured. Linked packages are shown when found in accessible buckets.\n"
+            )
 
         # Linked packages
         try:
@@ -210,7 +231,8 @@ class CanvasManager:
             linked_packages = search_result["packages"]
 
             # Filter out the primary package
-            linked_packages = [pkg for pkg in linked_packages if pkg.package_name != self.package_name]
+            if self.config.s3_bucket_name:
+                linked_packages = [pkg for pkg in linked_packages if pkg.package_name != self.package_name]
 
             # Store linked packages as instance variable
             self._linked_packages = linked_packages
@@ -247,25 +269,42 @@ class CanvasManager:
         if is_updating:
             # Render only the primary package header — skip the Athena query for
             # linked packages so the initial update returns quickly.
-            markdown_content = fmt.format_package_header(
-                package_name=self.package_name,
-                display_id=self.entry.display_id,
-                catalog_url=self.catalog_url,
-                sync_url=self.sync_uri(),
-            )
+            if self.config.s3_bucket_name:
+                markdown_content = fmt.format_package_header(
+                    package_name=self.package_name,
+                    display_id=self.entry.display_id,
+                    catalog_url=self.catalog_url,
+                    sync_url=self.sync_uri(),
+                )
+            else:
+                markdown_content = (
+                    f"## Benchling Entry\n\n"
+                    f"**Entry**: {self.entry.display_id}\n\n"
+                    "Bucketless mode is checking for linked packages.\n"
+                )
         else:
             markdown_content = self._make_markdown_content()
 
         markdown_block = blocks.create_markdown_block(markdown_content, "md1")
 
         result = [
-            *blocks.create_main_navigation_buttons(self.entry_id, update_enabled=not is_updating),
+            *blocks.create_main_navigation_buttons(
+                self.entry_id,
+                update_enabled=not is_updating and bool(self.config.s3_bucket_name),
+                browse_enabled=bool(self.config.s3_bucket_name),
+            ),
             markdown_block,
         ]
 
         # Add linked package browse buttons if any exist (skipped during initial update)
         if not is_updating and self._linked_packages:
-            result.extend(blocks.create_linked_package_browse_buttons(self.entry_id, self._linked_packages))
+            result.extend(
+                blocks.create_linked_package_browse_buttons(
+                    self.entry_id,
+                    self._linked_packages,
+                    include_bucket=not bool(self.config.s3_bucket_name),
+                )
+            )
 
         # Add footer as markdown block
         footer_markdown = fmt.format_canvas_footer(
@@ -424,6 +463,7 @@ class CanvasManager:
         context: str,
         page_state: Optional[PageState] = None,
         package_name: Optional[str] = None,
+        bucket_name: Optional[str] = None,
     ) -> List:
         """
         Create navigation buttons based on context, grouped in a section for horizontal layout.
@@ -437,15 +477,19 @@ class CanvasManager:
             List containing a SectionUiBlockUpdate with button children
         """
         if context == "main":
-            return blocks.create_main_navigation_buttons(self.entry_id)
+            return blocks.create_main_navigation_buttons(
+                self.entry_id,
+                update_enabled=bool(self.config.s3_bucket_name),
+                browse_enabled=bool(self.config.s3_bucket_name),
+            )
         if context == "browser":
             if page_state is None:
                 raise ValueError("page_state required for browser context")
-            return blocks.create_browser_navigation_buttons(self.entry_id, page_state, package_name)
+            return blocks.create_browser_navigation_buttons(self.entry_id, page_state, package_name, bucket_name)
         if context == "metadata":
             if page_state is None:
                 raise ValueError("page_state required for metadata context")
-            return blocks.create_metadata_navigation_buttons(self.entry_id, page_state, package_name)
+            return blocks.create_metadata_navigation_buttons(self.entry_id, page_state, package_name, bucket_name)
         raise ValueError(f"Unknown context: {context}")
 
     def get_package_browser_blocks(
@@ -453,6 +497,7 @@ class CanvasManager:
         page_number: int = 0,
         page_size: int = 15,
         package_name: Optional[str] = None,
+        bucket_name: Optional[str] = None,
     ) -> List:
         """Generate Package Entry Browser blocks for SDK use.
 
@@ -469,6 +514,7 @@ class CanvasManager:
         """
         # Use explicit package name if provided, otherwise use the default package name
         browsing_package_name = package_name or self.package_name
+        browsing_bucket_name = bucket_name or self.config.s3_bucket_name
 
         logger.info(
             "Generating Package Entry Browser blocks",
@@ -480,7 +526,7 @@ class CanvasManager:
 
         try:
             # Fetch all files - will raise exception if package doesn't exist
-            all_files = self._package_file_fetcher.get_package_files(browsing_package_name)
+            all_files = self._file_fetcher_for_bucket(browsing_bucket_name).get_package_files(browsing_package_name)
 
             if len(all_files) == 0:
                 # Package exists but empty
@@ -500,7 +546,7 @@ class CanvasManager:
             # Create blocks with package context for linked packages
             canvas_blocks = [
                 blocks.create_markdown_block(markdown, "md-browser"),
-                *self._make_navigation_buttons("browser", page_state, package_name),
+                *self._make_navigation_buttons("browser", page_state, package_name, browsing_bucket_name),
             ]
 
             logger.info(
@@ -560,6 +606,7 @@ class CanvasManager:
         page_number: int = 0,
         page_size: int = 15,
         package_name: Optional[str] = None,
+        bucket_name: Optional[str] = None,
     ) -> List:
         """Generate metadata view blocks for SDK use.
 
@@ -576,6 +623,7 @@ class CanvasManager:
         """
         # Use explicit package name if provided, otherwise use the default package name
         browsing_package_name = package_name or self.package_name
+        browsing_bucket_name = bucket_name or self.config.s3_bucket_name
 
         logger.info(
             "Generating metadata blocks",
@@ -584,7 +632,7 @@ class CanvasManager:
         )
 
         try:
-            metadata = self._package_file_fetcher.get_package_metadata(browsing_package_name)
+            metadata = self._file_fetcher_for_bucket(browsing_bucket_name).get_package_metadata(browsing_package_name)
 
             # Generate markdown
             markdown = self._make_metadata_markdown(metadata, browsing_package_name)
@@ -595,7 +643,7 @@ class CanvasManager:
             # Create blocks with package context for linked packages
             canvas_blocks = [
                 blocks.create_markdown_block(markdown, "md-metadata"),
-                *self._make_navigation_buttons("metadata", page_state, package_name),
+                *self._make_navigation_buttons("metadata", page_state, package_name, browsing_bucket_name),
             ]
 
             logger.info(

--- a/docker/src/canvas.py
+++ b/docker/src/canvas.py
@@ -5,6 +5,7 @@ package operations to specialized services.
 """
 
 import threading
+from datetime import datetime, timezone
 from typing import Any, List, Optional
 
 import structlog
@@ -293,7 +294,7 @@ class CanvasManager:
         result = [
             *blocks.create_main_navigation_buttons(
                 self.entry_id,
-                update_enabled=not is_updating,
+                update_enabled=not is_updating or not bool(self.config.s3_bucket_name),
                 browse_enabled=bool(self.config.s3_bucket_name),
                 bucketless=not bool(self.config.s3_bucket_name),
             ),
@@ -728,7 +729,10 @@ class CanvasManager:
         """Handle Canvas webhook payload."""
         try:
             logger.info("Updating canvas", canvas_id=self.canvas_id, entry_id=self.entry_id)
-            self.update_canvas()
+            updated_at = None
+            if not self.config.s3_bucket_name:
+                updated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+            self.update_canvas(updated_at=updated_at)
 
         except Exception as e:
             logger.error("Canvas operation failed", error=str(e), exc_info=True)

--- a/docker/src/canvas_blocks.py
+++ b/docker/src/canvas_blocks.py
@@ -270,7 +270,7 @@ def create_linked_package_browse_buttons(entry_id: str, packages: List[Package],
         button_id = f"browse-linked-{entry_id}-pkg-{encoded_pkg_name}{bucket_part}-p0-s15"
 
         # Create Browse button
-        button = create_button(button_id, pkg.package_name)
+        button = create_button(button_id, f"Browse {pkg.package_name}")
         buttons.append(button)
 
     # Create a section with all browse buttons in horizontal layout

--- a/docker/src/canvas_blocks.py
+++ b/docker/src/canvas_blocks.py
@@ -90,8 +90,13 @@ def create_section(section_id: str, buttons: List[ButtonUiBlock]) -> SectionUiBl
     )
 
 
-def create_main_navigation_buttons(entry_id: str, update_enabled: bool = True, browse_enabled: bool = True) -> List:
-    """Create main view navigation buttons (Browse Package, Update Package).
+def create_main_navigation_buttons(
+    entry_id: str,
+    update_enabled: bool = True,
+    browse_enabled: bool = True,
+    bucketless: bool = False,
+) -> List:
+    """Create main view navigation buttons.
 
     Args:
         entry_id: Entry identifier for button IDs
@@ -99,22 +104,34 @@ def create_main_navigation_buttons(entry_id: str, update_enabled: bool = True, b
             Used during the initial 'Updating...' state so a second click cannot
             spawn a concurrent export workflow. Browse stays enabled — on a
             re-export the previous package version is still valid.
+        browse_enabled: Whether the primary package browse button is enabled.
+        bucketless: If True, render bucketless controls instead of primary-package
+            controls. Bucketless mode has no default package to browse or update.
 
     Returns:
         List containing section with navigation buttons
     """
-    buttons = [
-        create_button(
-            button_id=f"browse-files-{entry_id}-p0-s15",
-            text="Browse Package",
-            enabled=browse_enabled,
-        ),
-        create_button(
-            button_id=f"update-package-{entry_id}",
-            text="Update Package",
-            enabled=update_enabled,
-        ),
-    ]
+    if bucketless:
+        buttons = [
+            create_button(
+                button_id=f"refresh-canvas-{entry_id}",
+                text="Refresh Canvas",
+                enabled=update_enabled,
+            ),
+        ]
+    else:
+        buttons = [
+            create_button(
+                button_id=f"browse-files-{entry_id}-p0-s15",
+                text="Browse Package",
+                enabled=browse_enabled,
+            ),
+            create_button(
+                button_id=f"update-package-{entry_id}",
+                text="Update Package",
+                enabled=update_enabled,
+            ),
+        ]
 
     return [create_section("button-section-main", buttons)]
 
@@ -124,6 +141,7 @@ def create_browser_navigation_buttons(
     page_state: PageState,
     package_name: Optional[str] = None,
     bucket_name: Optional[str] = None,
+    bucketless: bool = False,
 ) -> List:
     """Create browser view navigation buttons (Prev, Next, Back, Metadata).
 
@@ -169,7 +187,7 @@ def create_browser_navigation_buttons(
         ),
         create_button(
             button_id=f"back-to-package-{entry_id}",
-            text="Back to Package",
+            text="Back to Entry" if bucketless else "Back to Package",
             enabled=True,
         ),
         create_button(
@@ -187,6 +205,7 @@ def create_metadata_navigation_buttons(
     page_state: PageState,
     package_name: Optional[str] = None,
     bucket_name: Optional[str] = None,
+    bucketless: bool = False,
 ) -> List:
     """Create metadata view navigation buttons (Back to Browser, Back to Package).
 
@@ -216,7 +235,7 @@ def create_metadata_navigation_buttons(
         ),
         create_button(
             button_id=f"back-to-package-{entry_id}",
-            text="Back to Package",
+            text="Back to Entry" if bucketless else "Back to Package",
             enabled=True,
         ),
     ]

--- a/docker/src/canvas_blocks.py
+++ b/docker/src/canvas_blocks.py
@@ -15,7 +15,7 @@ from benchling_api_client.v2.stable.models.section_ui_block_type import SectionU
 from benchling_api_client.v2.stable.models.section_ui_block_update import SectionUiBlockUpdate
 
 from .packages import Package
-from .pagination import PageState, encode_package_name
+from .pagination import PageState, encode_bucket_name, encode_package_name
 
 
 def create_markdown_block(content: str, block_id: str = "md1") -> MarkdownUiBlockUpdate:
@@ -90,7 +90,7 @@ def create_section(section_id: str, buttons: List[ButtonUiBlock]) -> SectionUiBl
     )
 
 
-def create_main_navigation_buttons(entry_id: str, update_enabled: bool = True) -> List:
+def create_main_navigation_buttons(entry_id: str, update_enabled: bool = True, browse_enabled: bool = True) -> List:
     """Create main view navigation buttons (Browse Package, Update Package).
 
     Args:
@@ -107,6 +107,7 @@ def create_main_navigation_buttons(entry_id: str, update_enabled: bool = True) -
         create_button(
             button_id=f"browse-files-{entry_id}-p0-s15",
             text="Browse Package",
+            enabled=browse_enabled,
         ),
         create_button(
             button_id=f"update-package-{entry_id}",
@@ -122,6 +123,7 @@ def create_browser_navigation_buttons(
     entry_id: str,
     page_state: PageState,
     package_name: Optional[str] = None,
+    bucket_name: Optional[str] = None,
 ) -> List:
     """Create browser view navigation buttons (Prev, Next, Back, Metadata).
 
@@ -140,11 +142,14 @@ def create_browser_navigation_buttons(
     # If browsing a linked package, include package name in button IDs
     if package_name:
         encoded_pkg_name = encode_package_name(package_name)
-        prev_button_id = f"prev-page-linked-{entry_id}-pkg-{encoded_pkg_name}-p{prev_page}-s{page_state.page_size}"
-        next_button_id = f"next-page-linked-{entry_id}-pkg-{encoded_pkg_name}-p{next_page}-s{page_state.page_size}"
-        metadata_button_id = (
-            f"view-metadata-linked-{entry_id}-pkg-{encoded_pkg_name}-p{page_state.page_number}-s{page_state.page_size}"
+        bucket_part = f"-bucket-{encode_bucket_name(bucket_name)}" if bucket_name else ""
+        prev_button_id = (
+            f"prev-page-linked-{entry_id}-pkg-{encoded_pkg_name}{bucket_part}-p{prev_page}-s{page_state.page_size}"
         )
+        next_button_id = (
+            f"next-page-linked-{entry_id}-pkg-{encoded_pkg_name}{bucket_part}-p{next_page}-s{page_state.page_size}"
+        )
+        metadata_button_id = f"view-metadata-linked-{entry_id}-pkg-{encoded_pkg_name}{bucket_part}-p{page_state.page_number}-s{page_state.page_size}"
     else:
         # Default browsing (primary package)
         prev_button_id = f"prev-page-{entry_id}-p{prev_page}-s{page_state.page_size}"
@@ -181,6 +186,7 @@ def create_metadata_navigation_buttons(
     entry_id: str,
     page_state: PageState,
     package_name: Optional[str] = None,
+    bucket_name: Optional[str] = None,
 ) -> List:
     """Create metadata view navigation buttons (Back to Browser, Back to Package).
 
@@ -196,9 +202,8 @@ def create_metadata_navigation_buttons(
     # If browsing a linked package, include package name in "Back to Browser" button
     if package_name:
         encoded_pkg_name = encode_package_name(package_name)
-        back_to_browser_button_id = (
-            f"browse-linked-{entry_id}-pkg-{encoded_pkg_name}-p{page_state.page_number}-s{page_state.page_size}"
-        )
+        bucket_part = f"-bucket-{encode_bucket_name(bucket_name)}" if bucket_name else ""
+        back_to_browser_button_id = f"browse-linked-{entry_id}-pkg-{encoded_pkg_name}{bucket_part}-p{page_state.page_number}-s{page_state.page_size}"
     else:
         # Default browsing (primary package)
         back_to_browser_button_id = f"browse-files-{entry_id}-p{page_state.page_number}-s{page_state.page_size}"
@@ -219,7 +224,7 @@ def create_metadata_navigation_buttons(
     return [create_section("button-section-metadata", buttons)]
 
 
-def create_linked_package_browse_buttons(entry_id: str, packages: List[Package]) -> List:
+def create_linked_package_browse_buttons(entry_id: str, packages: List[Package], include_bucket: bool = False) -> List:
     """Create Browse buttons for linked packages.
 
     Creates a horizontal row of Browse buttons below the Linked Packages section.
@@ -242,8 +247,8 @@ def create_linked_package_browse_buttons(entry_id: str, packages: List[Package])
         # Encode package name for button ID (replace / with --)
         encoded_pkg_name = encode_package_name(pkg.package_name)
 
-        # Create button ID with default pagination (page 0, size 15)
-        button_id = f"browse-linked-{entry_id}-pkg-{encoded_pkg_name}-p0-s15"
+        bucket_part = f"-bucket-{encode_bucket_name(pkg.bucket)}" if include_bucket else ""
+        button_id = f"browse-linked-{entry_id}-pkg-{encoded_pkg_name}{bucket_part}-p0-s15"
 
         # Create Browse button
         button = create_button(button_id, pkg.package_name)

--- a/docker/src/canvas_formatting.py
+++ b/docker/src/canvas_formatting.py
@@ -149,21 +149,26 @@ Package `{package_name}` exists but contains no files.
 """
 
 
-def format_package_not_found(package_name: str) -> str:
+def format_package_not_found(package_name: str, can_create: bool = True) -> str:
     """Format package not found message.
 
     Args:
         package_name: Name of the package
+        can_create: Whether the current mode can create the missing package.
 
     Returns:
         Formatted markdown string
     """
-    return f"""## Package Not Created
+    md = f"""## Package Not Created
 
 Package `{package_name}` has not been created yet.
 
+"""
+    if can_create:
+        md += """\
 Click **Update Package** to create it.
 """
+    return md
 
 
 def format_error_loading_files(package_name: str, error: str) -> str:

--- a/docker/src/config.py
+++ b/docker/src/config.py
@@ -52,6 +52,7 @@ class Config:
     pkg_prefix: str = ""
     workflow: str = ""
     quilt_write_role_arn: str = ""
+    quilt_iceberg_database: str = ""
 
     # Secret fetching infrastructure (not the secrets themselves)
     _benchling_secret_name: str = ""
@@ -97,6 +98,11 @@ class Config:
 
         # Optional IAM role ARN for cross-account S3 access (v1.1.0+)
         self.quilt_write_role_arn = os.getenv("QUILT_WRITE_ROLE_ARN", "")
+
+        # Optional Iceberg database for bucketless search (v0.19.0+)
+        # When set, bucketless mode searches Iceberg manifest tables instead of
+        # fanning out concurrent Athena queries against _packages-view tables.
+        self.quilt_iceberg_database = os.getenv("QUILT_ICEBERG_DATABASE", "")
 
         # Optional Quilt service configuration (v0.8.0+)
         # Used by PackageQuery for Athena queries

--- a/docker/src/config.py
+++ b/docker/src/config.py
@@ -139,7 +139,7 @@ class Config:
                 '  "app_definition_id": "...",\n'
                 '  "pkg_prefix": "benchling",\n'
                 '  "pkg_key": "experiment_id",\n'
-                '  "user_bucket": "s3-bucket-name",\n'
+                '  "user_bucket": "s3-bucket-name (optional)",\n'
                 '  "log_level": "INFO",\n'
                 '  "enable_webhook_verification": "true"\n'
                 "}\n"
@@ -300,8 +300,8 @@ class Config:
         """
         # Set package/security config from secret (NOT environment variables!)
         if not self._test_mode:
-            # Package configuration ALWAYS comes from secret
-            self.s3_bucket_name = secret_data.user_bucket
+            # Package configuration comes from secret. Empty bucket means bucketless mode.
+            self.s3_bucket_name = secret_data.user_bucket or ""
             self.s3_prefix = secret_data.pkg_prefix or "benchling"
             self.pkg_prefix = self.s3_prefix
             self.package_key = secret_data.pkg_key or "experiment_id"

--- a/docker/src/config_schema.py
+++ b/docker/src/config_schema.py
@@ -176,7 +176,7 @@ class BenchlingSecret(BaseModel):
     client_id: str = Field(..., description="Benchling OAuth client ID")
     client_secret: str = Field(..., description="Benchling OAuth client secret")
     app_definition_id: str = Field(..., description="Benchling app definition ID")
-    user_bucket: str = Field(..., description="S3 bucket for package storage")
+    user_bucket: Optional[str] = Field(None, description="Optional S3 bucket for package storage")
     pkg_prefix: str = Field("benchling", description="S3 key prefix for packages")
     pkg_key: str = Field("experiment_id", description="Package metadata key")
     log_level: str = Field("INFO", description="Logging level")

--- a/docker/src/entry_packager.py
+++ b/docker/src/entry_packager.py
@@ -875,6 +875,18 @@ For questions about the data, refer to the original Benchling entry.
         """
         entry_id = payload.entry_id
 
+        if not self.config.s3_bucket_name:
+            self.logger.info(
+                "Bucketless mode skipped entry packaging workflow",
+                entry_id=entry_id,
+                event_type=payload.event_type,
+            )
+            return {
+                "status": "SKIPPED",
+                "entryId": entry_id,
+                "message": "Bucketless mode does not create a default package.",
+            }
+
         self.logger.info(
             "Starting workflow execution",
             entry_id=entry_id,

--- a/docker/src/package_event.py
+++ b/docker/src/package_event.py
@@ -80,6 +80,7 @@ def refresh_canvas_for_package_event(
     *,
     config: Config,
     benchling_factory: Callable[[], Benchling],
+    bucket: str | None = None,
 ) -> RefreshResult:
     """Refresh a canvas after Quilt publishes a package revision event."""
     try:
@@ -89,7 +90,7 @@ def refresh_canvas_for_package_event(
 
         package_fetcher = PackageFileFetcher(
             catalog_url=config.quilt_catalog,
-            bucket=config.s3_bucket_name,
+            bucket=bucket or config.s3_bucket_name,
             role_arn=config.quilt_write_role_arn or None,
             region=config.aws_region,
         )

--- a/docker/src/package_query.py
+++ b/docker/src/package_query.py
@@ -27,7 +27,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-import boto3
 import structlog
 
 from src.auth.role_manager import RoleManager

--- a/docker/src/package_query.py
+++ b/docker/src/package_query.py
@@ -19,6 +19,7 @@ Requires:
 import json
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import structlog
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
     from .config import Config
 
 logger = structlog.get_logger(__name__)
+
+DEFAULT_BUCKETLESS_SEARCH_WORKERS = 12
 
 
 class PackageQuery:
@@ -195,7 +198,13 @@ class PackageQuery:
                 buckets.append(table_name[: -len(suffix)])
         return sorted(set(buckets))
 
-    def _find_unique_packages_in_bucket(self, bucket: str, key: str, value: str) -> Dict[str, Any]:
+    def _find_unique_packages_in_bucket(
+        self,
+        bucket: str,
+        key: str,
+        value: str,
+        timeout: int = 30,
+    ) -> Dict[str, Any]:
         self.logger.info(
             "Searching for packages by metadata",
             key=key,
@@ -213,7 +222,7 @@ class PackageQuery:
         LIMIT 100
         """
 
-        rows = self._execute_query(query)
+        rows = self._execute_query(query, timeout=timeout)
 
         self.logger.info(
             "Query completed",
@@ -261,6 +270,67 @@ class PackageQuery:
             },
         }
 
+    def _bucketless_worker_count(self, bucket_count: int) -> int:
+        configured = os.getenv("BUCKETLESS_SEARCH_WORKERS")
+        if configured:
+            try:
+                worker_count = int(configured)
+            except ValueError:
+                self.logger.warning("Ignoring invalid BUCKETLESS_SEARCH_WORKERS value", value=configured)
+                worker_count = DEFAULT_BUCKETLESS_SEARCH_WORKERS
+        else:
+            worker_count = DEFAULT_BUCKETLESS_SEARCH_WORKERS
+
+        return max(1, min(worker_count, bucket_count))
+
+    def _find_unique_packages_in_all_buckets(self, key: str, value: str) -> Dict[str, Any]:
+        buckets = self._list_package_view_buckets()
+        all_packages: List[Package] = []
+        rows: List[Dict[str, Any]] = []
+        package_info: Dict[str, Dict[str, Any]] = {}
+        errors: Dict[str, str] = {}
+
+        if not buckets:
+            return {
+                "packages": all_packages,
+                "results": {
+                    "rows": rows,
+                    "package_info": package_info,
+                    "errors": errors,
+                },
+            }
+
+        workers = self._bucketless_worker_count(len(buckets))
+        self.logger.info("Searching package views concurrently", bucket_count=len(buckets), workers=workers)
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(self._find_unique_packages_in_bucket, bucket, key, value, 10): bucket
+                for bucket in buckets
+            }
+            for future in as_completed(futures):
+                bucket = futures[future]
+                try:
+                    bucket_result = future.result()
+                except Exception as exc:
+                    errors[bucket] = str(exc)
+                    self.logger.warning("Bucket package lookup failed", bucket=bucket, error=str(exc))
+                    continue
+
+                all_packages.extend(bucket_result["packages"])
+                rows.extend(bucket_result["results"]["rows"])
+                for name, info in bucket_result["results"]["package_info"].items():
+                    package_info[f"{info['bucket']}/{name}"] = info
+
+        return {
+            "packages": sorted(all_packages, key=lambda p: (p.bucket, p.package_name)),
+            "results": {
+                "rows": rows,
+                "package_info": package_info,
+                "errors": errors,
+            },
+        }
+
     def find_unique_packages(self, key: str, value: str) -> Dict[str, Any]:
         """Find unique packages matching metadata key-value pair.
 
@@ -295,32 +365,7 @@ class PackageQuery:
             if self.bucket:
                 result = self._find_unique_packages_in_bucket(self.bucket, key, value)
             else:
-                buckets = self._list_package_view_buckets()
-                all_packages: List[Package] = []
-                rows: List[Dict[str, Any]] = []
-                package_info: Dict[str, Dict[str, Any]] = {}
-                errors: Dict[str, str] = {}
-
-                for bucket in buckets:
-                    try:
-                        bucket_result = self._find_unique_packages_in_bucket(bucket, key, value)
-                    except Exception as exc:
-                        errors[bucket] = str(exc)
-                        self.logger.warning("Bucket package lookup failed", bucket=bucket, error=str(exc))
-                        continue
-                    all_packages.extend(bucket_result["packages"])
-                    rows.extend(bucket_result["results"]["rows"])
-                    for name, info in bucket_result["results"]["package_info"].items():
-                        package_info[f"{info['bucket']}/{name}"] = info
-
-                result = {
-                    "packages": sorted(all_packages, key=lambda p: (p.bucket, p.package_name)),
-                    "results": {
-                        "rows": rows,
-                        "package_info": package_info,
-                        "errors": errors,
-                    },
-                }
+                result = self._find_unique_packages_in_all_buckets(key, value)
 
             self.logger.info(
                 "Found unique packages",

--- a/docker/src/package_query.py
+++ b/docker/src/package_query.py
@@ -184,7 +184,7 @@ class PackageQuery:
         SELECT table_name
         FROM information_schema.tables
         WHERE table_schema = '{self.database}'
-            AND table_name LIKE '%_packages-view'
+            AND table_name LIKE '%\\_packages-view' ESCAPE '\\'
         """
         rows = self._execute_query(query)
         buckets: List[str] = []

--- a/docker/src/package_query.py
+++ b/docker/src/package_query.py
@@ -179,6 +179,88 @@ class PackageQuery:
 
         return data_rows
 
+    def _list_package_view_buckets(self) -> List[str]:
+        query = f"""
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = '{self.database}'
+            AND table_name LIKE '%_packages-view'
+        """
+        rows = self._execute_query(query)
+        buckets: List[str] = []
+        suffix = "_packages-view"
+        for row in rows:
+            table_name = row.get("table_name") or row.get("TABLE_NAME")
+            if isinstance(table_name, str) and table_name.endswith(suffix):
+                buckets.append(table_name[: -len(suffix)])
+        return sorted(set(buckets))
+
+    def _find_unique_packages_in_bucket(self, bucket: str, key: str, value: str) -> Dict[str, Any]:
+        self.logger.info(
+            "Searching for packages by metadata",
+            key=key,
+            value=value,
+            bucket=bucket,
+        )
+
+        view_name = f'"{self.database}"."{bucket}_packages-view"'
+
+        query = f"""
+        SELECT pkg_name, timestamp, message, user_meta
+        FROM {view_name}
+        WHERE json_extract_scalar(user_meta, '$.{key}') = '{value}'
+            AND timestamp = 'latest'
+        LIMIT 100
+        """
+
+        rows = self._execute_query(query)
+
+        self.logger.info(
+            "Query completed",
+            row_count=len(rows),
+            key=key,
+            value=value,
+            bucket=bucket,
+        )
+
+        package_info: Dict[str, Dict[str, Any]] = {}
+
+        for row in rows:
+            pkg_name = row["pkg_name"]
+            user_meta_str = row.get("user_meta", "{}")
+
+            try:
+                user_meta = json.loads(user_meta_str) if user_meta_str else {}
+            except json.JSONDecodeError:
+                self.logger.warning("Failed to parse user_meta JSON", pkg_name=pkg_name)
+                user_meta = {}
+
+            if pkg_name not in package_info:
+                package_info[pkg_name] = {
+                    "bucket": bucket,
+                    "versions": [],
+                    "metadata": user_meta,
+                    "timestamp": row.get("timestamp"),
+                    "message": row.get("message"),
+                }
+
+        packages = [
+            Package(
+                catalog_base_url=self.catalog_url,
+                bucket=info["bucket"],
+                package_name=name,
+            )
+            for name, info in sorted(package_info.items())
+        ]
+
+        return {
+            "packages": packages,
+            "results": {
+                "rows": rows,
+                "package_info": package_info,
+            },
+        }
+
     def find_unique_packages(self, key: str, value: str) -> Dict[str, Any]:
         """Find unique packages matching metadata key-value pair.
 
@@ -203,83 +285,50 @@ class PackageQuery:
             >>> for pkg in packages:
             ...     print(f"{pkg.package_name}: {pkg.catalog_url}")
         """
-        self.logger.info(
-            "Searching for packages by metadata",
-            key=key,
-            value=value,
-            bucket=self.bucket,
-        )
-
-        # Build the view name from bucket
-        view_name = f'"{self.database}"."{self.bucket}_packages-view"'
-
-        # Build SQL query using json_extract_scalar for proper JSON querying
-        # Filter by timestamp = 'latest' to get only the most recent version
-        query = f"""
-        SELECT pkg_name, timestamp, message, user_meta
-        FROM {view_name}
-        WHERE json_extract_scalar(user_meta, '$.{key}') = '{value}'
-            AND timestamp = 'latest'
-        LIMIT 100
-        """
-
         try:
-            rows = self._execute_query(query)
-
             self.logger.info(
-                "Query completed",
-                row_count=len(rows),
+                "Searching for packages by metadata",
                 key=key,
                 value=value,
+                bucket=self.bucket,
             )
+            if self.bucket:
+                result = self._find_unique_packages_in_bucket(self.bucket, key, value)
+            else:
+                buckets = self._list_package_view_buckets()
+                all_packages: List[Package] = []
+                rows: List[Dict[str, Any]] = []
+                package_info: Dict[str, Dict[str, Any]] = {}
+                errors: Dict[str, str] = {}
 
-            # Group results by package name
-            package_info: Dict[str, Dict[str, Any]] = {}
+                for bucket in buckets:
+                    try:
+                        bucket_result = self._find_unique_packages_in_bucket(bucket, key, value)
+                    except Exception as exc:
+                        errors[bucket] = str(exc)
+                        self.logger.warning("Bucket package lookup failed", bucket=bucket, error=str(exc))
+                        continue
+                    all_packages.extend(bucket_result["packages"])
+                    rows.extend(bucket_result["results"]["rows"])
+                    for name, info in bucket_result["results"]["package_info"].items():
+                        package_info[f"{info['bucket']}/{name}"] = info
 
-            for row in rows:
-                pkg_name = row["pkg_name"]
-                user_meta_str = row.get("user_meta", "{}")
-
-                # Parse metadata to get additional info
-                try:
-                    user_meta = json.loads(user_meta_str) if user_meta_str else {}
-                except json.JSONDecodeError:
-                    self.logger.warning("Failed to parse user_meta JSON", pkg_name=pkg_name)
-                    user_meta = {}
-
-                # Add to package_info
-                if pkg_name not in package_info:
-                    package_info[pkg_name] = {
-                        "bucket": self.bucket,
-                        "versions": [],
-                        "metadata": user_meta,
-                        "timestamp": row.get("timestamp"),
-                        "message": row.get("message"),
-                    }
-
-            # Create Package instances
-            packages = [
-                Package(
-                    catalog_base_url=self.catalog_url,
-                    bucket=info["bucket"],
-                    package_name=name,
-                )
-                for name, info in sorted(package_info.items())
-            ]
+                result = {
+                    "packages": sorted(all_packages, key=lambda p: (p.bucket, p.package_name)),
+                    "results": {
+                        "rows": rows,
+                        "package_info": package_info,
+                        "errors": errors,
+                    },
+                }
 
             self.logger.info(
                 "Found unique packages",
-                package_count=len(packages),
-                packages=[p.package_name for p in packages],
+                package_count=len(result["packages"]),
+                packages=[f"{p.bucket}/{p.package_name}" for p in result["packages"]],
             )
 
-            return {
-                "packages": packages,
-                "results": {
-                    "rows": rows,
-                    "package_info": package_info,
-                },
-            }
+            return result
 
         except Exception as e:
             error_msg = str(e)

--- a/docker/src/package_query.py
+++ b/docker/src/package_query.py
@@ -23,6 +23,7 @@ For Iceberg-backed bucketless search (v0.19.0+):
 
 import json
 import os
+import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -44,6 +45,8 @@ _ICEBERG_MANIFEST_SUFFIX = "_package_manifest"
 
 # Suffix for the per-bucket parquet-backed packages-view.
 _PACKAGES_VIEW_SUFFIX = "_packages-view"
+
+_METADATA_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class PackageQuery:
@@ -213,6 +216,73 @@ class PackageQuery:
 
         return data_rows
 
+    def _validate_metadata_key(self, key: str) -> str:
+        """Validate a metadata key before using it as a SQL identifier."""
+        if not _METADATA_KEY_RE.match(key):
+            raise ValueError(
+                f"Invalid metadata key '{key}'. Iceberg metadata keys must be SQL-safe identifiers "
+                "matching [A-Za-z_][A-Za-z0-9_]*."
+            )
+        return key
+
+    def _parse_user_meta(self, raw_meta: Optional[str], *, pkg_name: str, key: str, value: str) -> Dict[str, Any]:
+        """Parse metadata returned from Athena, falling back to the matched key/value."""
+        if not raw_meta:
+            return {key: value}
+
+        try:
+            parsed = json.loads(raw_meta)
+            if isinstance(parsed, dict):
+                return parsed
+            self.logger.warning(
+                "Athena metadata JSON was not an object",
+                pkg_name=pkg_name,
+                metadata_type=type(parsed).__name__,
+            )
+        except json.JSONDecodeError:
+            self.logger.warning("Failed to parse user_meta JSON", pkg_name=pkg_name)
+
+        return {key: value}
+
+    def _format_aws_error(self, error: Exception) -> str:
+        """Return an actionable error message for common AWS query failures."""
+        error_msg = str(error)
+        response = getattr(error, "response", None)
+        operation = getattr(error, "operation_name", "") or ""
+        code = ""
+        if isinstance(response, dict):
+            code = response.get("Error", {}).get("Code", "")
+            operation = operation or response.get("ResponseMetadata", {}).get("OperationName", "")
+
+        lowered = error_msg.lower()
+        access_denied = (
+            "accessdenied" in lowered
+            or "access denied" in lowered
+            or "not authorized" in lowered
+            or code in {"AccessDenied", "AccessDeniedException", "UnauthorizedOperation"}
+        )
+
+        if not access_denied:
+            return error_msg
+
+        if operation.lower() == "gettables" or "get_tables" in lowered or "glue" in lowered:
+            return (
+                "AWS Glue access denied. Please check IAM permissions for "
+                f"glue:GetTables on Iceberg database '{self.iceberg_database or '(not configured)'}'."
+            )
+
+        if operation.lower() in {"startqueryexecution", "getqueryexecution", "getqueryresults"} or "athena" in lowered:
+            return (
+                "AWS Athena access denied. Please check IAM permissions for "
+                f"athena query execution on workgroup '{self.workgroup}'."
+            )
+
+        return (
+            "AWS access denied while searching for linked packages. Please check task role "
+            f"permissions for Athena workgroup '{self.workgroup}' and Iceberg database "
+            f"'{self.iceberg_database or '(not configured)'}'."
+        )
+
     # ------------------------------------------------------------------
     # Parquet-backed _packages-view search (legacy, for non-Iceberg deployments)
     # ------------------------------------------------------------------
@@ -272,11 +342,7 @@ class PackageQuery:
             pkg_name = row["pkg_name"]
             user_meta_str = row.get("user_meta", "{}")
 
-            try:
-                user_meta = json.loads(user_meta_str) if user_meta_str else {}
-            except json.JSONDecodeError:
-                self.logger.warning("Failed to parse user_meta JSON", pkg_name=pkg_name)
-                user_meta = {}
+            user_meta = self._parse_user_meta(user_meta_str, pkg_name=pkg_name, key=key, value=value)
 
             if pkg_name not in package_info:
                 package_info[pkg_name] = {
@@ -438,11 +504,14 @@ class PackageQuery:
                 r.pkg_name,
                 r.timestamp,
                 m.message,
-                m.metadata AS user_meta,
+                json_format(CAST(m.metadata AS JSON)) AS user_meta,
                 '{b}' AS _src_bucket
             FROM "{idb}"."{b}_package_revision" r
             JOIN "{idb}"."{b}_package_manifest" m ON r.top_hash = m.top_hash
-            JOIN "{idb}"."{b}_package_tag" t ON r.pkg_name = t.pkg_name AND t.tag_name = 'latest'
+            JOIN "{idb}"."{b}_package_tag" t
+                ON r.pkg_name = t.pkg_name
+                AND r.top_hash = t.top_hash
+                AND t.tag_name = 'latest'
             WHERE m.metadata.{key} = '{escaped_value}'
             """
             branches.append(branch)
@@ -492,11 +561,7 @@ class PackageQuery:
             pkg_name = row["pkg_name"]
             user_meta_str = row.get("user_meta", "{}")
 
-            try:
-                user_meta = json.loads(user_meta_str) if user_meta_str else {}
-            except json.JSONDecodeError:
-                self.logger.warning("Failed to parse user_meta JSON", pkg_name=pkg_name)
-                user_meta = {}
+            user_meta = self._parse_user_meta(user_meta_str, pkg_name=pkg_name, key=key, value=value)
 
             composite_key = f"{bucket}/{pkg_name}"
             if composite_key not in package_info:
@@ -556,6 +621,8 @@ class PackageQuery:
             ...     print(f"{pkg.package_name}: {pkg.catalog_url}")
         """
         try:
+            self._validate_metadata_key(key)
+
             self.logger.info(
                 "Searching for packages by metadata",
                 key=key,
@@ -583,13 +650,7 @@ class PackageQuery:
             return result
 
         except Exception as e:
-            error_msg = str(e)
-            # Extract more helpful information from AWS errors
-            if "AccessDeniedException" in error_msg or "not authorized" in error_msg.lower():
-                error_msg = (
-                    "AWS Athena access denied. Please check IAM permissions for "
-                    f"athena:StartQueryExecution on database '{self.database}'"
-                )
+            error_msg = self._format_aws_error(e)
 
             self.logger.error(
                 "Query failed",

--- a/docker/src/package_query.py
+++ b/docker/src/package_query.py
@@ -481,15 +481,18 @@ class PackageQuery:
         """Build a single UNION ALL query across Iceberg tables for all buckets.
 
         Joins package_revision ↔ package_manifest on top_hash, filtered to
-        'latest' tag via package_tag, and filters on metadata.{key} = '{value}'.
-        STRUCT field access is schema-native — no json_extract_scalar needed.
+        'latest' tag via package_tag, and filters on the metadata key/value.
 
-        The metadata column in Iceberg is a native Athena STRUCT, so accessing
-        a field by name is faster than json_extract_scalar on a raw JSON string.
+        The Iceberg package_manifest.metadata column is populated from the
+        packages-view user_meta column (see quilt_shared.iceberg_queries:
+        ``user_meta AS metadata``), which is a raw JSON string — NOT a native
+        Athena STRUCT. Accessing it as ``m.metadata.{key}`` raises
+        ``TYPE_MISMATCH: Expression m.metadata is not of type ROW``, so we use
+        json_extract_scalar just like the parquet _packages-view path.
 
         Args:
             buckets: List of bucket names to search
-            key: Metadata key to filter on (used as STRUCT field name)
+            key: Metadata key to filter on (JSON path field name)
             value: Metadata value to match
 
         Returns:
@@ -512,7 +515,7 @@ class PackageQuery:
                 ON r.pkg_name = t.pkg_name
                 AND r.top_hash = t.top_hash
                 AND t.tag_name = 'latest'
-            WHERE m.metadata.{key} = '{escaped_value}'
+            WHERE json_extract_scalar(m.metadata, '$.{key}') = '{escaped_value}'
             """
             branches.append(branch)
 

--- a/docker/src/package_query.py
+++ b/docker/src/package_query.py
@@ -4,8 +4,8 @@ This module provides an alternative to PackageSearcher that queries
 the Athena database directly instead of using Elasticsearch via quilt3.search().
 
 Responsibilities:
-- Query Athena's {bucket}_packages-view
-- Search for packages by metadata key-value pairs using json_extract_scalar
+- Query Athena's {bucket}_packages-view (parquet-backed) or Iceberg manifest tables
+- Search for packages by metadata key-value pairs
 - Return Package instances matching the search criteria
 - Use RoleManager for cross-account Athena access
 
@@ -14,6 +14,11 @@ Requires:
 - QUILT_USER_BUCKET environment variable for the registry (bucket)
 - QUILT_WRITE_ROLE_ARN environment variable for cross-account access (optional)
 - AWS credentials configured for Athena access
+
+For Iceberg-backed bucketless search (v0.19.0+):
+- QUILT_ICEBERG_DATABASE environment variable with Iceberg Glue database name
+  When set, bucketless mode uses a single Iceberg query instead of fanning out
+  concurrent Athena queries.
 """
 
 import json
@@ -22,6 +27,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+import boto3
 import structlog
 
 from src.auth.role_manager import RoleManager
@@ -34,6 +40,12 @@ logger = structlog.get_logger(__name__)
 
 DEFAULT_BUCKETLESS_SEARCH_WORKERS = 12
 
+# Suffix for the per-bucket Iceberg package_manifest table.
+_ICEBERG_MANIFEST_SUFFIX = "_package_manifest"
+
+# Suffix for the per-bucket parquet-backed packages-view.
+_PACKAGES_VIEW_SUFFIX = "_packages-view"
+
 
 class PackageQuery:
     """Query Athena database for packages by metadata.
@@ -44,6 +56,10 @@ class PackageQuery:
 
     The Athena database contains a packages view per bucket:
     - {bucket}_packages-view: Contains pkg_name, timestamp, message, user_meta
+
+    When an Iceberg database is configured and no specific bucket is set (bucketless),
+    it uses Iceberg manifest tables for faster, single-query search instead of
+    concurrent fanout.
     """
 
     def __init__(
@@ -54,6 +70,7 @@ class PackageQuery:
         region: Optional[str] = None,
         workgroup: Optional[str] = None,
         config: Optional["Config"] = None,
+        iceberg_database: Optional[str] = None,
     ):
         """Initialize Athena query client.
 
@@ -66,6 +83,10 @@ class PackageQuery:
                 Query results are managed automatically by the workgroup's AWS-managed configuration.
             config: Optional Config instance for reading configuration (v0.8.0+)
                 If provided, will use config.athena_user_workgroup as fallback before env vars.
+            iceberg_database: Optional Iceberg Glue database name (v0.19.0+)
+                When set and bucket is empty (bucketless), uses Iceberg manifest tables
+                for single-query search instead of concurrent fanout across _packages-view
+                tables. Overrides config.quilt_iceberg_database if provided.
         """
         self.bucket = bucket
         self.catalog_url = catalog_url
@@ -76,6 +97,13 @@ class PackageQuery:
 
         if not self.database:
             raise ValueError("database parameter or QUILT_DATABASE environment variable required")
+
+        # Iceberg database for bucketless optimized search
+        self.iceberg_database = (
+            iceberg_database
+            or (config.quilt_iceberg_database if config else "")
+            or os.getenv("QUILT_ICEBERG_DATABASE", "")
+        )
 
         # Initialize RoleManager for cross-account access
         role_arn = None
@@ -103,9 +131,13 @@ class PackageQuery:
         # Note: AWS-managed workgroups handle query results automatically
         # No need to specify output location - workgroup configuration takes precedence
 
+        # Lazily initialized Glue client (for listing Iceberg tables)
+        self._glue = None
+
         self.logger.info(
             "Initialized PackageQuery",
             database=self.database,
+            iceberg_database=self.iceberg_database or "(not configured)",
             bucket=bucket,
             catalog=catalog_url,
             region=self.region,
@@ -182,6 +214,10 @@ class PackageQuery:
 
         return data_rows
 
+    # ------------------------------------------------------------------
+    # Parquet-backed _packages-view search (legacy, for non-Iceberg deployments)
+    # ------------------------------------------------------------------
+
     def _list_package_view_buckets(self) -> List[str]:
         query = f"""
         SELECT table_name
@@ -191,11 +227,10 @@ class PackageQuery:
         """
         rows = self._execute_query(query)
         buckets: List[str] = []
-        suffix = "_packages-view"
         for row in rows:
             table_name = row.get("table_name") or row.get("TABLE_NAME")
-            if isinstance(table_name, str) and table_name.endswith(suffix):
-                buckets.append(table_name[: -len(suffix)])
+            if isinstance(table_name, str) and table_name.endswith(_PACKAGES_VIEW_SUFFIX):
+                buckets.append(table_name[: -len(_PACKAGES_VIEW_SUFFIX)])
         return sorted(set(buckets))
 
     def _find_unique_packages_in_bucket(
@@ -331,11 +366,177 @@ class PackageQuery:
             },
         }
 
+    # ------------------------------------------------------------------
+    # Iceberg-backed search (v0.19.0+: single-query, no fanout)
+    # ------------------------------------------------------------------
+
+    def _glue_client(self):
+        """Lazily initialize a Glue client from the assumed-role session."""
+        if self._glue is None:
+            session = self.role_manager._get_or_create_session(
+                self.role_manager.role_arn,
+                self.role_manager._session,
+                self.role_manager._expires_at,
+            )[0]
+            self._glue = session.client("glue", region_name=self.region)
+        return self._glue
+
+    def _list_iceberg_manifest_buckets(self) -> List[str]:
+        """List buckets with Iceberg package_manifest tables via Glue API.
+
+        Uses the Glue get_tables API (not Athena information_schema) since
+        the Iceberg tables live in a different Glue database than the main
+        Athena query context.
+
+        Returns:
+            Sorted list of bucket names (without the '_package_manifest' suffix).
+        """
+        glue = self._glue_client()
+        buckets: List[str] = []
+        next_token: Optional[str] = None
+
+        while True:
+            kwargs: Dict[str, Any] = {"DatabaseName": self.iceberg_database}
+            if next_token:
+                kwargs["NextToken"] = next_token
+
+            response = glue.get_tables(**kwargs)
+            for table in response.get("TableList", []):
+                name = table.get("Name", "")
+                if name.endswith(_ICEBERG_MANIFEST_SUFFIX):
+                    buckets.append(name[: -len(_ICEBERG_MANIFEST_SUFFIX)])
+
+            next_token = response.get("NextToken")
+            if not next_token:
+                break
+
+        return sorted(set(buckets))
+
+    def _build_iceberg_union_query(self, buckets: List[str], key: str, value: str) -> str:
+        """Build a single UNION ALL query across Iceberg tables for all buckets.
+
+        Joins package_revision ↔ package_manifest on top_hash, filtered to
+        'latest' tag via package_tag, and filters on metadata.{key} = '{value}'.
+        STRUCT field access is schema-native — no json_extract_scalar needed.
+
+        The metadata column in Iceberg is a native Athena STRUCT, so accessing
+        a field by name is faster than json_extract_scalar on a raw JSON string.
+
+        Args:
+            buckets: List of bucket names to search
+            key: Metadata key to filter on (used as STRUCT field name)
+            value: Metadata value to match
+
+        Returns:
+            Complete SQL query string with one UNION ALL branch per bucket.
+        """
+        escaped_value = value.replace("'", "''")
+        idb = self.iceberg_database
+        branches: List[str] = []
+        for b in buckets:
+            branch = f"""
+            SELECT
+                r.pkg_name,
+                r.timestamp,
+                m.message,
+                m.metadata AS user_meta,
+                '{b}' AS _src_bucket
+            FROM "{idb}"."{b}_package_revision" r
+            JOIN "{idb}"."{b}_package_manifest" m ON r.top_hash = m.top_hash
+            JOIN "{idb}"."{b}_package_tag" t ON r.pkg_name = t.pkg_name AND t.tag_name = 'latest'
+            WHERE m.metadata.{key} = '{escaped_value}'
+            """
+            branches.append(branch)
+
+        return "\nUNION ALL\n".join(branches)
+
+    def _find_unique_packages_in_iceberg(self, key: str, value: str) -> Dict[str, Any]:
+        """Search for packages across all Iceberg-managed buckets using a single query.
+
+        Replaces the concurrent fanout with one Athena query using UNION ALL
+        across all buckets' Iceberg manifest tables.
+
+        Returns:
+            Same structure as _find_unique_packages_in_all_buckets()
+        """
+        buckets = self._list_iceberg_manifest_buckets()
+
+        if not buckets:
+            self.logger.info("No Iceberg manifest tables found", iceberg_database=self.iceberg_database)
+            return {
+                "packages": [],
+                "results": {
+                    "rows": [],
+                    "package_info": {},
+                    "errors": {},
+                },
+            }
+
+        self.logger.info(
+            "Searching Iceberg manifests with single query",
+            bucket_count=len(buckets),
+            iceberg_database=self.iceberg_database,
+            key=key,
+            value=value,
+        )
+
+        query = self._build_iceberg_union_query(buckets, key, value)
+        rows = self._execute_query(query, timeout=60)
+
+        self.logger.info("Iceberg query completed", row_count=len(rows))
+
+        package_info: Dict[str, Dict[str, Any]] = {}
+        errors: Dict[str, str] = {}
+
+        for row in rows:
+            bucket = row.get("_src_bucket", "")
+            pkg_name = row["pkg_name"]
+            user_meta_str = row.get("user_meta", "{}")
+
+            try:
+                user_meta = json.loads(user_meta_str) if user_meta_str else {}
+            except json.JSONDecodeError:
+                self.logger.warning("Failed to parse user_meta JSON", pkg_name=pkg_name)
+                user_meta = {}
+
+            composite_key = f"{bucket}/{pkg_name}"
+            if composite_key not in package_info:
+                package_info[composite_key] = {
+                    "bucket": bucket,
+                    "pkg_name": pkg_name,
+                    "versions": [],
+                    "metadata": user_meta,
+                    "timestamp": row.get("timestamp"),
+                    "message": row.get("message"),
+                }
+
+        packages = [
+            Package(
+                catalog_base_url=self.catalog_url,
+                bucket=info["bucket"],
+                package_name=info["pkg_name"],
+            )
+            for info in sorted(package_info.values(), key=lambda i: (i["bucket"], i["pkg_name"]))
+        ]
+
+        return {
+            "packages": sorted(packages, key=lambda p: (p.bucket, p.package_name)),
+            "results": {
+                "rows": rows,
+                "package_info": package_info,
+                "errors": errors,
+            },
+        }
+
     def find_unique_packages(self, key: str, value: str) -> Dict[str, Any]:
         """Find unique packages matching metadata key-value pair.
 
         Queries the {bucket}_packages-view for packages with user_meta containing
         the specified key-value pair using json_extract_scalar.
+
+        When in bucketless mode (bucket is empty) and an Iceberg database is
+        configured, uses a single-query Iceberg UNION ALL instead of concurrent
+        fanout across _packages-view tables.
 
         Args:
             key: Metadata key to search for (e.g., "entry_id", "id", "display_id")
@@ -360,12 +561,19 @@ class PackageQuery:
                 "Searching for packages by metadata",
                 key=key,
                 value=value,
-                bucket=self.bucket,
+                bucket=self.bucket or "(bucketless)",
+                iceberg_database=self.iceberg_database or "(not configured)",
             )
-            if self.bucket:
-                result = self._find_unique_packages_in_bucket(self.bucket, key, value)
-            else:
+
+            # Bucketless with Iceberg: single-query path (fastest)
+            if not self.bucket and self.iceberg_database:
+                result = self._find_unique_packages_in_iceberg(key, value)
+            # Bucketless without Iceberg: concurrent fanout (legacy fallback)
+            elif not self.bucket:
                 result = self._find_unique_packages_in_all_buckets(key, value)
+            # Specific bucket: direct single-bucket query
+            else:
+                result = self._find_unique_packages_in_bucket(self.bucket, key, value)
 
             self.logger.info(
                 "Found unique packages",

--- a/docker/src/pagination.py
+++ b/docker/src/pagination.py
@@ -9,6 +9,12 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 
+# S3 bucket naming rules: 3-63 chars, lowercase letters/digits/dots/hyphens,
+# beginning and ending with a letter or digit. Used to disambiguate the optional
+# "-bucket-" segment in linked-package button IDs from package names that happen
+# to contain the literal substring "-bucket-".
+_BUCKET_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
+
 
 def encode_package_name(package_name: str) -> str:
     """Encode package name for button ID.
@@ -146,7 +152,12 @@ def parse_browse_linked_button_id_with_bucket(button_id: str) -> tuple[str, str,
 
     encoded_bucket = None
     if "-bucket-" in encoded_pkg:
-        encoded_pkg, encoded_bucket = encoded_pkg.rsplit("-bucket-", 1)
+        candidate_pkg, candidate_bucket = encoded_pkg.rsplit("-bucket-", 1)
+        # Only treat the trailing segment as a bucket when it is a valid S3 bucket
+        # name; otherwise "-bucket-" is part of the package name itself and must
+        # not be split off (which would corrupt both package and bucket names).
+        if _BUCKET_NAME_RE.match(candidate_bucket):
+            encoded_pkg, encoded_bucket = candidate_pkg, candidate_bucket
 
     package_name = decode_package_name(encoded_pkg)
     bucket_name = decode_bucket_name(encoded_bucket) if encoded_bucket else None

--- a/docker/src/pagination.py
+++ b/docker/src/pagination.py
@@ -51,36 +51,73 @@ def decode_package_name(encoded_name: str) -> str:
 
 
 def encode_bucket_name(bucket_name: str) -> str:
-    return bucket_name.replace("/", "--")
+    """Encode bucket name for button ID (identity function).
+
+    S3 bucket names are restricted to lowercase letters, numbers, dots,
+    and hyphens, so no encoding is needed — they embed safely in button IDs.
+
+    Args:
+        bucket_name: S3 bucket name (e.g., 'quiltdata-test')
+
+    Returns:
+        The bucket name unchanged.
+
+    Examples:
+        >>> encode_bucket_name('quiltdata-test')
+        'quiltdata-test'
+    """
+    return bucket_name
 
 
 def decode_bucket_name(encoded_name: str) -> str:
-    return encoded_name.replace("--", "/")
+    """Decode bucket name from button ID (identity function).
+
+    S3 bucket names are restricted to lowercase letters, numbers, dots,
+    and hyphens, so no decoding is needed.
+
+    Args:
+        encoded_name: Bucket name from button ID (e.g., 'quiltdata-test')
+
+    Returns:
+        The name unchanged.
+
+    Examples:
+        >>> decode_bucket_name('quiltdata-test')
+        'quiltdata-test'
+    """
+    return encoded_name
 
 
 def parse_browse_linked_button_id_with_bucket(button_id: str) -> tuple[str, str, Optional[str], int, int]:
     """Parse linked package button ID.
 
     Supports multiple button formats:
-    - browse-linked-{entry_id}-pkg-{encoded_pkg}-p{page}-s{size}
-    - next-page-linked-{entry_id}-pkg-{encoded_pkg}-p{page}-s{size}
-    - prev-page-linked-{entry_id}-pkg-{encoded_pkg}-p{page}-s{size}
-    - view-metadata-linked-{entry_id}-pkg-{encoded_pkg}-p{page}-s{size}
+    - browse-linked-{entry_id}-pkg-{encoded_pkg}[-bucket-{bucket_name}]-p{page}-s{size}
+    - next-page-linked-{entry_id}-pkg-{encoded_pkg}[-bucket-{bucket_name}]-p{page}-s{size}
+    - prev-page-linked-{entry_id}-pkg-{encoded_pkg}[-bucket-{bucket_name}]-p{page}-s{size}
+    - view-metadata-linked-{entry_id}-pkg-{encoded_pkg}[-bucket-{bucket_name}]-p{page}-s{size}
+
+    When a linked package belongs to a different bucket than the one configured for
+    the webhook, the bucket name is embedded as an optional `-bucket-` segment.
+    The bucket name segment is absent when the linked package is in the same bucket.
 
     Args:
         button_id: Button ID string to parse
 
     Returns:
-        Tuple of (entry_id, package_name, page_number, page_size)
+        Tuple of (entry_id, package_name, bucket_name, page_number, page_size)
+        bucket_name is None when no bucket segment was present.
 
     Raises:
         ValueError: If button ID format is invalid
 
     Examples:
-        >>> parse_browse_linked_button_id('browse-linked-etr_123-pkg-benchling--exp-001-p0-s15')
-        ('etr_123', 'benchling/exp-001', 0, 15)
-        >>> parse_browse_linked_button_id('next-page-linked-etr_abc-pkg-foo--bar--baz-p2-s20')
-        ('etr_abc', 'foo/bar/baz', 2, 20)
+        >>> parse_browse_linked_button_id_with_bucket('browse-linked-etr_123-pkg-benchling--exp-001-p0-s15')
+        ('etr_123', 'benchling/exp-001', None, 0, 15)
+        >>> parse_browse_linked_button_id_with_bucket('next-page-linked-etr_abc-pkg-foo--bar--baz-p2-s20')
+        ('etr_abc', 'foo/bar/baz', None, 2, 20)
+        >>> parse_browse_linked_button_id_with_bucket('browse-linked-etr_456-pkg-benchling--exp-002-bucket-quiltdata-test-p0-s10')
+        ('etr_456', 'benchling/exp-002', 'quiltdata-test', 0, 10)
     """
     # Check if this is a linked package button (contains "-linked-" and "-pkg-")
     if "-linked-" not in button_id or "-pkg-" not in button_id:

--- a/docker/src/pagination.py
+++ b/docker/src/pagination.py
@@ -50,7 +50,15 @@ def decode_package_name(encoded_name: str) -> str:
     return encoded_name.replace("--", "/")
 
 
-def parse_browse_linked_button_id(button_id: str) -> tuple[str, str, int, int]:
+def encode_bucket_name(bucket_name: str) -> str:
+    return bucket_name.replace("/", "--")
+
+
+def decode_bucket_name(encoded_name: str) -> str:
+    return encoded_name.replace("--", "/")
+
+
+def parse_browse_linked_button_id_with_bucket(button_id: str) -> tuple[str, str, Optional[str], int, int]:
     """Parse linked package button ID.
 
     Supports multiple button formats:
@@ -99,8 +107,12 @@ def parse_browse_linked_button_id(button_id: str) -> tuple[str, str, int, int]:
 
     encoded_pkg, rest = rest.rsplit("-p", 1)
 
-    # Decode package name: replace "--" back to "/"
+    encoded_bucket = None
+    if "-bucket-" in encoded_pkg:
+        encoded_pkg, encoded_bucket = encoded_pkg.rsplit("-bucket-", 1)
+
     package_name = decode_package_name(encoded_pkg)
+    bucket_name = decode_bucket_name(encoded_bucket) if encoded_bucket else None
 
     # Extract page and size
     if "-s" not in rest:
@@ -114,6 +126,11 @@ def parse_browse_linked_button_id(button_id: str) -> tuple[str, str, int, int]:
     except ValueError as e:
         raise ValueError(f"Invalid page/size in button ID: {button_id}") from e
 
+    return (entry_id, package_name, bucket_name, page_number, page_size)
+
+
+def parse_browse_linked_button_id(button_id: str) -> tuple[str, str, int, int]:
+    entry_id, package_name, _bucket_name, page_number, page_size = parse_browse_linked_button_id_with_bucket(button_id)
     return (entry_id, package_name, page_number, page_size)
 
 

--- a/docker/src/secrets_manager.py
+++ b/docker/src/secrets_manager.py
@@ -11,7 +11,7 @@ Usage:
 """
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 import structlog
 from botocore.exceptions import ClientError
@@ -61,7 +61,8 @@ class BenchlingSecretData:
         pkg_prefix: Quilt package name prefix
         pkg_key: Metadata key for linking Benchling entries to Quilt packages
         workflow: Optional Quilt workflow name for package creation
-        user_bucket: S3 bucket name for Benchling exports
+        user_bucket: Optional S3 bucket name for Benchling exports. When absent,
+                     the webhook runs in bucketless mode.
         log_level: Application logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
         enable_webhook_verification: Enable Lambda authorizer webhook verification (boolean)
         queue_url: SQS queue URL for package creation (optional, v0.8.0+ gets from env)
@@ -76,11 +77,10 @@ class BenchlingSecretData:
     # Quilt Package Configuration
     pkg_prefix: str
     pkg_key: str
-    user_bucket: str
-
     # Application Behavior
     log_level: str
     enable_webhook_verification: bool
+    user_bucket: Optional[str] = None
     workflow: str = ""
 
     # Optional: SQS queue URL (v0.8.0+ gets from environment variable instead)
@@ -190,7 +190,6 @@ def fetch_benchling_secret(client, region: str, secret_identifier: str) -> Bench
             "app_definition_id",
             "pkg_prefix",
             "pkg_key",
-            "user_bucket",
             "log_level",
             "enable_webhook_verification",
         ]
@@ -204,7 +203,7 @@ def fetch_benchling_secret(client, region: str, secret_identifier: str) -> Bench
                 "app_definition_id": "appdef_wqFfaXBVMu",
                 "pkg_prefix": "benchling",
                 "pkg_key": "experiment_id",
-                "user_bucket": "my-s3-bucket",
+                "user_bucket": "my-s3-bucket (optional)",
                 "log_level": "INFO",
                 "enable_webhook_verification": "true",
             }
@@ -244,7 +243,6 @@ def fetch_benchling_secret(client, region: str, secret_identifier: str) -> Bench
             "app_definition_id",
             "pkg_prefix",
             "pkg_key",
-            "user_bucket",
         ]
         for param in string_params:
             if not isinstance(data[param], str) or len(data[param]) == 0:
@@ -264,7 +262,7 @@ def fetch_benchling_secret(client, region: str, secret_identifier: str) -> Bench
             app_definition_id=data["app_definition_id"],
             pkg_prefix=data["pkg_prefix"],
             pkg_key=data["pkg_key"],
-            user_bucket=data["user_bucket"],
+            user_bucket=data.get("user_bucket") or None,
             workflow=data.get("workflow", ""),
             log_level=data["log_level"],
             enable_webhook_verification=enable_webhook_verification,

--- a/docker/src/sqs_consumer.py
+++ b/docker/src/sqs_consumer.py
@@ -197,7 +197,7 @@ class SqsConsumer(BaseSqsConsumer):
             top_hash = parsed.top_hash
 
             expected_prefix = f"{self.config.pkg_prefix}/"
-            if parsed.bucket != self.config.s3_bucket_name:
+            if self.config.s3_bucket_name and parsed.bucket != self.config.s3_bucket_name:
                 outcome = "skipped_filtered"
                 should_delete = True
                 logger.info(
@@ -223,6 +223,7 @@ class SqsConsumer(BaseSqsConsumer):
                     parsed.top_hash,
                     config=self.config,
                     benchling_factory=self.benchling_factory,
+                    bucket=parsed.bucket,
                 )
                 outcome = result.outcome.value
                 should_delete = outcome in DELETE_OUTCOMES

--- a/docker/tests/conftest.py
+++ b/docker/tests/conftest.py
@@ -23,6 +23,7 @@ def isolate_environment(monkeypatch):
         "QUEUE_URL",
         "QUILT_CATALOG",
         "QUILT_DATABASE",
+        "QUILT_ICEBERG_DATABASE",
         "AWS_REGION",
         "PKG_PREFIX",
         "PKG_KEY",

--- a/docker/tests/test_app.py
+++ b/docker/tests/test_app.py
@@ -206,6 +206,34 @@ class TestFastAPIApp:
         updating_manager.send_updating_canvas.assert_called_once()
         final_manager.handle_async.assert_called_once()
 
+    def test_canvas_endpoint_bucketless_refresh_canvas_button(self, client, mock_config, mock_publish):
+        """Refresh Canvas should rerun the bucketless linked-package lookup."""
+        mock_config.s3_bucket_name = ""
+        payload = {
+            "channel": "app_signals",
+            "message": {
+                "type": "v2.canvas.userInteracted",
+                "buttonId": "refresh-canvas-etr_123456",
+                "canvasId": "canvas_123",
+            },
+            "baseURL": "https://tenant.benchling.com",
+        }
+
+        with patch("src.app.CanvasManager") as mock_canvas_manager:
+            updating_manager = MagicMock()
+            final_manager = MagicMock()
+            mock_canvas_manager.side_effect = [updating_manager, final_manager]
+
+            response = client.post("/canvas", json=payload)
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "ACCEPTED"
+        assert data["message"] == "Refreshing canvas..."
+        mock_publish.assert_not_called()
+        updating_manager.send_updating_canvas.assert_called_once()
+        final_manager.handle_async.assert_called_once()
+
     @pytest.mark.local
     def test_canvas_endpoint_handles_browse_files_button(self, client, mock_benchling_client):
         """Test /canvas endpoint routes Browse Files button to correct handler.

--- a/docker/tests/test_app.py
+++ b/docker/tests/test_app.py
@@ -120,6 +120,23 @@ class TestFastAPIApp:
         assert data["status"] == "ACCEPTED"
         mock_publish.assert_called_once()
 
+    def test_webhook_endpoint_bucketless_skips_packaging(self, client, mock_config, mock_publish):
+        """Bucketless entry events should not enqueue default package creation."""
+        mock_config.s3_bucket_name = ""
+        payload = {
+            "channel": "events",
+            "message": {"type": "v2.entry.created", "resourceId": "etr_123456"},
+            "baseURL": "https://tenant.benchling.com",
+        }
+
+        response = client.post("/event", json=payload)
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "SKIPPED"
+        assert data["mode"] == "bucketless"
+        mock_publish.assert_not_called()
+
     def test_webhook_endpoint_no_payload(self, client):
         """Test webhook endpoint with no JSON payload."""
         response = client.post("/event", data="", headers={"Content-Type": "application/json"})

--- a/docker/tests/test_app.py
+++ b/docker/tests/test_app.py
@@ -181,6 +181,31 @@ class TestFastAPIApp:
         published_payload = mock_publish.call_args.args[2]
         assert published_payload.canvas_id == "canvas_123"
 
+    def test_canvas_endpoint_bucketless_starts_final_canvas_update(self, client, mock_config, mock_publish):
+        """Bucketless Canvas initialization should not leave the updating placeholder forever."""
+        mock_config.s3_bucket_name = ""
+        payload = {
+            "channel": "events",
+            "message": {"type": "v2.canvas.initialized", "resourceId": "etr_123456"},
+            "baseURL": "https://tenant.benchling.com",
+            "context": {"canvasId": "canvas_123"},
+        }
+
+        with patch("src.app.CanvasManager") as mock_canvas_manager:
+            updating_manager = MagicMock()
+            final_manager = MagicMock()
+            mock_canvas_manager.side_effect = [updating_manager, final_manager]
+
+            response = client.post("/canvas", json=payload)
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "SKIPPED"
+        assert data["mode"] == "bucketless"
+        mock_publish.assert_not_called()
+        updating_manager.send_updating_canvas.assert_called_once()
+        final_manager.handle_async.assert_called_once()
+
     @pytest.mark.local
     def test_canvas_endpoint_handles_browse_files_button(self, client, mock_benchling_client):
         """Test /canvas endpoint routes Browse Files button to correct handler.

--- a/docker/tests/test_app.py
+++ b/docker/tests/test_app.py
@@ -234,6 +234,38 @@ class TestFastAPIApp:
         updating_manager.send_updating_canvas.assert_called_once()
         final_manager.handle_async.assert_called_once()
 
+    def test_canvas_endpoint_refresh_canvas_creates_default_package_when_bucket_configured(
+        self, client, mock_config, mock_publish
+    ):
+        """Refresh Canvas on a stale bucketless canvas should create the default
+        package once a bucket has been configured (not return an error)."""
+        mock_config.s3_bucket_name = "test-bucket"
+        payload = {
+            "channel": "app_signals",
+            "message": {
+                "type": "v2.canvas.userInteracted",
+                "buttonId": "refresh-canvas-etr_123456",
+                "canvasId": "canvas_123",
+            },
+            "baseURL": "https://tenant.benchling.com",
+        }
+
+        with patch("src.app.CanvasManager") as mock_canvas_manager:
+            updating_manager = MagicMock()
+            final_manager = MagicMock()
+            mock_canvas_manager.side_effect = [updating_manager, final_manager]
+
+            response = client.post("/canvas", json=payload)
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "ACCEPTED"
+        assert data["message"] == "Creating default package..."
+        assert data["sqs_message_id"] == "msg-id-test"
+        mock_publish.assert_called_once()
+        updating_manager.send_updating_canvas.assert_called_once()
+        final_manager.handle_async.assert_called_once()
+
     @pytest.mark.local
     def test_canvas_endpoint_handles_browse_files_button(self, client, mock_benchling_client):
         """Test /canvas endpoint routes Browse Files button to correct handler.

--- a/docker/tests/test_browse_linked_packages.py
+++ b/docker/tests/test_browse_linked_packages.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.canvas_blocks import create_linked_package_browse_buttons
+from src.canvas_blocks import create_linked_package_browse_buttons, create_main_navigation_buttons
 from src.packages import Package
 from src.pagination import decode_package_name, encode_package_name, parse_browse_linked_button_id
 
@@ -430,7 +430,26 @@ class TestLinkedPackageBrowseButtons:
         assert hasattr(button, "id")
         assert hasattr(button, "text")
         assert hasattr(button, "enabled")
-        assert button.type == "BUTTON"
+
+    def test_bucketless_main_navigation_has_refresh_only(self):
+        """Bucketless main Canvas should not show unusable primary package buttons."""
+        result = create_main_navigation_buttons("etr_123", bucketless=True)
+
+        assert len(result) == 1
+        buttons = result[0].children
+        assert len(buttons) == 1
+        assert buttons[0].id == "refresh-canvas-etr_123"
+        assert buttons[0].text == "Refresh Canvas"
+        assert buttons[0].enabled is True
+
+    def test_bucketless_main_navigation_disables_refresh_while_updating(self):
+        """The initial checking state should not allow duplicate refresh clicks."""
+        result = create_main_navigation_buttons("etr_123", update_enabled=False, bucketless=True)
+
+        buttons = result[0].children
+        assert len(buttons) == 1
+        assert buttons[0].text == "Refresh Canvas"
+        assert buttons[0].enabled is False
 
 
 class TestRoundtripIntegration:

--- a/docker/tests/test_browse_linked_packages.py
+++ b/docker/tests/test_browse_linked_packages.py
@@ -294,7 +294,7 @@ class TestLinkedPackageBrowseButtons:
         buttons = result[0].children
         assert len(buttons) == 1
         assert buttons[0].type == "BUTTON"
-        assert buttons[0].text == "benchling/exp-001"
+        assert buttons[0].text == "Browse benchling/exp-001"
         assert buttons[0].id == "browse-linked-etr_123-pkg-benchling--exp-001-p0-s15"
         assert buttons[0].enabled is True
 
@@ -320,6 +320,9 @@ class TestLinkedPackageBrowseButtons:
         assert buttons[0].id == "browse-linked-etr_abc-pkg-benchling--exp-001-p0-s15"
         assert buttons[1].id == "browse-linked-etr_abc-pkg-benchling--exp-002-p0-s15"
         assert buttons[2].id == "browse-linked-etr_abc-pkg-benchling--exp-003-p0-s15"
+        assert buttons[0].text == "Browse benchling/exp-001"
+        assert buttons[1].text == "Browse benchling/exp-002"
+        assert buttons[2].text == "Browse benchling/exp-003"
 
         # All buttons should be enabled
         assert all(btn.enabled is True for btn in buttons)

--- a/docker/tests/test_canvas_updating_blocks.py
+++ b/docker/tests/test_canvas_updating_blocks.py
@@ -66,6 +66,15 @@ def canvas_manager(mock_benchling, mock_config, mock_payload):
     return CanvasManager(benchling=mock_benchling, config=mock_config, payload=mock_payload)
 
 
+@pytest.fixture
+def bucketless_canvas_manager(mock_benchling, mock_config, mock_payload):
+    mock_config.s3_bucket_name = ""
+    manager = CanvasManager(benchling=mock_benchling, config=mock_config, payload=mock_payload)
+    manager._package_query = Mock()
+    manager._package_query.find_unique_packages.return_value = {"packages": []}
+    return manager
+
+
 def _dump_blocks(label: str, block_dicts: list) -> None:
     """Pretty-print a set of blocks so the UX can be eyeballed."""
     print(f"\n================ {label} ================")
@@ -194,3 +203,28 @@ class TestUpdatingCanvasBlocks:
         assert "FINAL 'Updated at ...' CANVAS" in captured.out
         assert "Updating..." in captured.out
         assert "Updated at 2026-04-15 12:00 UTC" in captured.out
+
+    def test_bucketless_updating_canvas_has_disabled_refresh(self, bucketless_canvas_manager):
+        """Bucketless checking state should show Refresh Canvas, disabled until final render."""
+        updating = bucketless_canvas_manager._make_blocks(is_updating=True)
+        buttons = updating[0].children
+
+        assert len(buttons) == 1
+        assert buttons[0].text == "Refresh Canvas"
+        assert buttons[0].enabled is False
+        assert "Bucketless mode is checking for linked packages" in updating[1].value
+        assert "Updating..." in updating[-1].value
+
+    def test_bucketless_final_canvas_has_refresh_and_no_package_buttons(self, bucketless_canvas_manager):
+        """Final bucketless Canvas should be actionable without implying a default package exists."""
+        final = bucketless_canvas_manager._make_blocks()
+        buttons = final[0].children
+
+        assert len(buttons) == 1
+        assert buttons[0].text == "Refresh Canvas"
+        assert buttons[0].enabled is True
+        assert "Browse Package" not in json.dumps(blocks_to_dict(final))
+        assert "Update Package" not in json.dumps(blocks_to_dict(final))
+        assert "No default package bucket is configured" in final[1].value
+        assert "No linked packages found in accessible buckets" in final[1].value
+        assert "Updating..." not in final[-1].value

--- a/docker/tests/test_canvas_updating_blocks.py
+++ b/docker/tests/test_canvas_updating_blocks.py
@@ -63,16 +63,27 @@ def mock_benchling():
 
 @pytest.fixture
 def canvas_manager(mock_benchling, mock_config, mock_payload):
-    return CanvasManager(benchling=mock_benchling, config=mock_config, payload=mock_payload)
+    package_query = Mock()
+    package_query.find_unique_packages.return_value = {"packages": []}
+    return CanvasManager(
+        benchling=mock_benchling,
+        config=mock_config,
+        payload=mock_payload,
+        package_query=package_query,
+    )
 
 
 @pytest.fixture
 def bucketless_canvas_manager(mock_benchling, mock_config, mock_payload):
     mock_config.s3_bucket_name = ""
-    manager = CanvasManager(benchling=mock_benchling, config=mock_config, payload=mock_payload)
-    manager._package_query = Mock()
-    manager._package_query.find_unique_packages.return_value = {"packages": []}
-    return manager
+    package_query = Mock()
+    package_query.find_unique_packages.return_value = {"packages": []}
+    return CanvasManager(
+        benchling=mock_benchling,
+        config=mock_config,
+        payload=mock_payload,
+        package_query=package_query,
+    )
 
 
 def _dump_blocks(label: str, block_dicts: list) -> None:
@@ -204,14 +215,14 @@ class TestUpdatingCanvasBlocks:
         assert "Updating..." in captured.out
         assert "Updated at 2026-04-15 12:00 UTC" in captured.out
 
-    def test_bucketless_updating_canvas_has_disabled_refresh(self, bucketless_canvas_manager):
-        """Bucketless checking state should show Refresh Canvas, disabled until final render."""
+    def test_bucketless_updating_canvas_has_active_refresh(self, bucketless_canvas_manager):
+        """Bucketless checking state should leave Refresh Canvas clickable."""
         updating = bucketless_canvas_manager._make_blocks(is_updating=True)
         buttons = updating[0].children
 
         assert len(buttons) == 1
         assert buttons[0].text == "Refresh Canvas"
-        assert buttons[0].enabled is False
+        assert buttons[0].enabled is True
         assert "Bucketless mode is checking for linked packages" in updating[1].value
         assert "Updating..." in updating[-1].value
 
@@ -228,3 +239,12 @@ class TestUpdatingCanvasBlocks:
         assert "No default package bucket is configured" in final[1].value
         assert "No linked packages found in accessible buckets" in final[1].value
         assert "Updating..." not in final[-1].value
+
+    def test_bucketless_async_handle_sets_updated_at(self, bucketless_canvas_manager):
+        """Bucketless final render should mark the Canvas as updated, not pending."""
+        bucketless_canvas_manager.update_canvas = Mock()
+
+        bucketless_canvas_manager._handle()
+
+        kwargs = bucketless_canvas_manager.update_canvas.call_args.kwargs
+        assert kwargs["updated_at"].endswith(" UTC")

--- a/docker/tests/test_config_validation.py
+++ b/docker/tests/test_config_validation.py
@@ -99,6 +99,15 @@ class TestSecretValidation:
         assert secret.enable_webhook_verification is True
         assert secret.workflow == ""
 
+    def test_secret_without_user_bucket_is_bucketless(self, mock_sm_client, valid_secret_data):
+        """Test that user_bucket is optional for bucketless mode."""
+        del valid_secret_data["user_bucket"]
+        mock_sm_client.get_secret_value.return_value = {"SecretString": json.dumps(valid_secret_data)}
+
+        secret = fetch_benchling_secret(mock_sm_client, "us-east-1", "test-secret")
+
+        assert secret.user_bucket is None
+
     def test_optional_workflow_is_accepted(self, mock_sm_client, valid_secret_data):
         """Test that optional workflow is parsed when present."""
         valid_secret_data["workflow"] = "custom-workflow"
@@ -136,7 +145,6 @@ class TestSecretValidation:
         """Test that missing multiple parameters lists all missing."""
         del valid_secret_data["log_level"]
         del valid_secret_data["pkg_prefix"]
-        del valid_secret_data["user_bucket"]
 
         mock_sm_client.get_secret_value.return_value = {"SecretString": json.dumps(valid_secret_data)}
 
@@ -147,7 +155,6 @@ class TestSecretValidation:
         assert "Missing required parameters" in error_message
         assert "log_level" in error_message
         assert "pkg_prefix" in error_message
-        assert "user_bucket" in error_message
 
     def test_invalid_log_level(self, mock_sm_client, valid_secret_data):
         """Test that invalid log level raises error."""

--- a/docker/tests/test_package_query.py
+++ b/docker/tests/test_package_query.py
@@ -417,10 +417,12 @@ class TestPackageQueryIceberg:
         # Should reference both buckets
         assert "bucket-a" in sql
         assert "bucket-b" in sql
-        # Should access metadata as STRUCT
-        assert "metadata.experiment_id" in sql
         # Should serialize metadata deterministically for Python parsing
         assert "json_format(CAST(m.metadata AS JSON)) AS user_meta" in sql
+        # metadata is a JSON string (from user_meta), not a native STRUCT, so
+        # it must be filtered via json_extract_scalar to avoid TYPE_MISMATCH.
+        assert "json_extract_scalar(m.metadata, '$.experiment_id')" in sql
+        assert "m.metadata.experiment_id" not in sql
         # Should have _src_bucket alias
         assert "_src_bucket" in sql
         # Should filter on 'latest' tag

--- a/docker/tests/test_package_query.py
+++ b/docker/tests/test_package_query.py
@@ -419,14 +419,123 @@ class TestPackageQueryIceberg:
         assert "bucket-b" in sql
         # Should access metadata as STRUCT
         assert "metadata.experiment_id" in sql
+        # Should serialize metadata deterministically for Python parsing
+        assert "json_format(CAST(m.metadata AS JSON)) AS user_meta" in sql
         # Should have _src_bucket alias
         assert "_src_bucket" in sql
         # Should filter on 'latest' tag
         assert "tag_name = 'latest'" in sql
+        # Should constrain the selected revision to the latest tag top_hash
+        assert "r.top_hash = t.top_hash" in sql
         # Should join package_revision + package_manifest + package_tag
         assert "package_revision" in sql
         assert "package_manifest" in sql
         assert "package_tag" in sql
+
+    @patch("src.package_query.RoleManager")
+    def test_iceberg_rejects_unsafe_metadata_key(self, mock_role_manager_class):
+        """Metadata keys used as SQL identifiers must be validated."""
+        mock_athena = Mock()
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.return_value = mock_athena
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(
+            bucket="",
+            catalog_url="catalog.example.com",
+            database="test_db",
+            region="us-west-2",
+            iceberg_database="iceberg_db",
+        )
+
+        with pytest.raises(RuntimeError, match="Invalid metadata key"):
+            query.find_unique_packages("experiment-id", "EXP-1")
+
+    @patch("src.package_query.RoleManager")
+    def test_iceberg_non_object_metadata_keeps_package_match(self, mock_role_manager_class):
+        """Athena STRUCT serialization problems should not hide package matches."""
+        mock_athena = Mock()
+        mock_glue = Mock()
+
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.side_effect = lambda service, **kw: {
+            "athena": mock_athena,
+            "glue": mock_glue,
+        }[service]
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(
+            bucket="",
+            catalog_url="catalog.example.com",
+            database="test_db",
+            region="us-west-2",
+            iceberg_database="iceberg_db",
+        )
+
+        query._list_iceberg_manifest_buckets = Mock(return_value=["bucket-a"])
+        query._execute_query = Mock(
+            return_value=[
+                {
+                    "pkg_name": "benchling/pkg-a",
+                    "timestamp": "latest",
+                    "message": "A",
+                    "user_meta": '["EXP-1"]',
+                    "_src_bucket": "bucket-a",
+                }
+            ]
+        )
+
+        result = query.find_unique_packages("experiment_id", "EXP-1")
+
+        assert [(pkg.bucket, pkg.package_name) for pkg in result["packages"]] == [
+            ("bucket-a", "benchling/pkg-a"),
+        ]
+        assert result["results"]["package_info"]["bucket-a/benchling/pkg-a"]["metadata"] == {
+            "experiment_id": "EXP-1",
+        }
+
+    @patch("src.package_query.RoleManager")
+    def test_iceberg_glue_access_denied_reports_glue_database(self, mock_role_manager_class):
+        """Glue table-list permission failures should not be reported as Athena DB failures."""
+        mock_athena = Mock()
+
+        class FakeGlueAccessDenied(Exception):
+            operation_name = "GetTables"
+            response = {"Error": {"Code": "AccessDeniedException"}}
+
+            def __str__(self):
+                return "AccessDeniedException: not authorized"
+
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.return_value = mock_athena
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(
+            bucket="",
+            catalog_url="catalog.example.com",
+            database="test_db",
+            region="us-west-2",
+            iceberg_database="iceberg_db",
+        )
+        query._list_iceberg_manifest_buckets = Mock(side_effect=FakeGlueAccessDenied())
+
+        with pytest.raises(RuntimeError, match="AWS Glue access denied"):
+            query.find_unique_packages("experiment_id", "EXP-1")
 
     @patch("src.package_query.RoleManager")
     def test_iceberg_with_multiple_matches_per_bucket(self, mock_role_manager_class):

--- a/docker/tests/test_package_query.py
+++ b/docker/tests/test_package_query.py
@@ -134,3 +134,87 @@ class TestPackageQuery:
         assert package.package_name == "benchling/etr_123"
         assert package.bucket == "test-bucket"
         assert package.catalog_base_url == "catalog.example.com"
+
+    @patch("src.package_query.RoleManager")
+    def test_find_unique_packages_bucketless_searches_all_package_views(self, mock_role_manager_class):
+        """Bucketless PackageQuery searches every discovered package view."""
+        mock_athena = Mock()
+        mock_athena.start_query_execution.side_effect = [
+            {"QueryExecutionId": "list-query"},
+            {"QueryExecutionId": "bucket-a-query"},
+            {"QueryExecutionId": "bucket-b-query"},
+        ]
+        mock_athena.get_query_execution.return_value = {"QueryExecution": {"Status": {"State": "SUCCEEDED"}}}
+        mock_athena.get_query_results.side_effect = [
+            {
+                "ResultSet": {
+                    "Rows": [
+                        {"Data": [{"VarCharValue": "table_name"}]},
+                        {"Data": [{"VarCharValue": "bucket-a_packages-view"}]},
+                        {"Data": [{"VarCharValue": "bucket-b_packages-view"}]},
+                    ]
+                }
+            },
+            {
+                "ResultSet": {
+                    "Rows": [
+                        {
+                            "Data": [
+                                {"VarCharValue": "pkg_name"},
+                                {"VarCharValue": "timestamp"},
+                                {"VarCharValue": "message"},
+                                {"VarCharValue": "user_meta"},
+                            ]
+                        },
+                        {
+                            "Data": [
+                                {"VarCharValue": "benchling/pkg-a"},
+                                {"VarCharValue": "latest"},
+                                {"VarCharValue": "A"},
+                                {"VarCharValue": '{"experiment_id": "EXP-1"}'},
+                            ]
+                        },
+                    ]
+                }
+            },
+            {
+                "ResultSet": {
+                    "Rows": [
+                        {
+                            "Data": [
+                                {"VarCharValue": "pkg_name"},
+                                {"VarCharValue": "timestamp"},
+                                {"VarCharValue": "message"},
+                                {"VarCharValue": "user_meta"},
+                            ]
+                        },
+                        {
+                            "Data": [
+                                {"VarCharValue": "benchling/pkg-b"},
+                                {"VarCharValue": "latest"},
+                                {"VarCharValue": "B"},
+                                {"VarCharValue": '{"experiment_id": "EXP-1"}'},
+                            ]
+                        },
+                    ]
+                }
+            },
+        ]
+
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.return_value = mock_athena
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(bucket="", catalog_url="catalog.example.com", database="test_db")
+
+        result = query.find_unique_packages("experiment_id", "EXP-1")
+
+        assert [(pkg.bucket, pkg.package_name) for pkg in result["packages"]] == [
+            ("bucket-a", "benchling/pkg-a"),
+            ("bucket-b", "benchling/pkg-b"),
+        ]

--- a/docker/tests/test_package_query.py
+++ b/docker/tests/test_package_query.py
@@ -220,3 +220,267 @@ class TestPackageQuery:
 
         assert [(pkg.bucket, pkg.package_name) for pkg in result["packages"]] == [("bucket-b", "benchling/pkg-b")]
         assert result["results"]["errors"] == {"bucket-a": "Access denied"}
+
+
+class TestPackageQueryIceberg:
+    """Tests for Iceberg-backed bucketless search path."""
+
+    @patch("src.package_query.RoleManager")
+    def test_iceberg_query_taken_when_configured(self, mock_role_manager_class):
+        """Bucketless + iceberg_database uses Iceberg path, not fanout."""
+        mock_athena = Mock()
+        mock_glue = Mock()
+
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.side_effect = lambda service, **kw: {
+            "athena": mock_athena,
+            "glue": mock_glue,
+        }[service]
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(
+            bucket="",
+            catalog_url="catalog.example.com",
+            database="test_db",
+            region="us-west-2",
+            iceberg_database="iceberg_db",
+        )
+
+        # Mock the Iceberg methods so we don't need real Glue data
+        query._list_iceberg_manifest_buckets = Mock(return_value=["bucket-a", "bucket-b"])
+        query._execute_query = Mock(
+            return_value=[
+                {
+                    "pkg_name": "benchling/pkg-a",
+                    "timestamp": "latest",
+                    "message": "A",
+                    "user_meta": '{"experiment_id": "EXP-1"}',
+                    "_src_bucket": "bucket-a",
+                },
+                {
+                    "pkg_name": "benchling/pkg-b",
+                    "timestamp": "latest",
+                    "message": "B",
+                    "user_meta": '{"experiment_id": "EXP-1"}',
+                    "_src_bucket": "bucket-b",
+                },
+            ]
+        )
+
+        result = query.find_unique_packages("experiment_id", "EXP-1")
+
+        assert [(pkg.bucket, pkg.package_name) for pkg in result["packages"]] == [
+            ("bucket-a", "benchling/pkg-a"),
+            ("bucket-b", "benchling/pkg-b"),
+        ]
+        query._list_iceberg_manifest_buckets.assert_called_once()
+        assert query._execute_query.call_count == 1  # single query, not fanout
+
+    @patch("src.package_query.RoleManager")
+    def test_iceberg_skipped_when_not_configured(self, mock_role_manager_class):
+        """Bucketless without iceberg_database falls back to fanout."""
+        mock_athena = Mock()
+
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.return_value = mock_athena
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(
+            bucket="",
+            catalog_url="catalog.example.com",
+            database="test_db",
+            region="us-west-2",
+        )
+        # Should use fanout path
+        query._list_package_view_buckets = Mock(return_value=[])
+        query._find_unique_packages_in_bucket = Mock(return_value={"packages": [], "results": {}})
+
+        result = query.find_unique_packages("experiment_id", "EXP-1")
+
+        query._list_package_view_buckets.assert_called_once()
+        assert query._find_unique_packages_in_bucket.call_count == 0  # no buckets to search
+
+    @patch("src.package_query.RoleManager")
+    def test_single_bucket_taken_when_bucket_set(self, mock_role_manager_class):
+        """When bucket is set, single-bucket path is used even with iceberg_database."""
+        mock_athena = Mock()
+
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.return_value = mock_athena
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(
+            bucket="my-bucket",
+            catalog_url="catalog.example.com",
+            database="test_db",
+            region="us-west-2",
+            iceberg_database="iceberg_db",
+        )
+        query._find_unique_packages_in_bucket = Mock(
+            return_value={
+                "packages": [Package("catalog.example.com", "my-bucket", "benchling/pkg")],
+                "results": {},
+            }
+        )
+
+        result = query.find_unique_packages("experiment_id", "EXP-1")
+
+        query._find_unique_packages_in_bucket.assert_called_once_with("my-bucket", "experiment_id", "EXP-1")
+
+    @patch("src.package_query.RoleManager")
+    def test_iceberg_empty_when_no_tables_found(self, mock_role_manager_class):
+        """Iceberg path returns empty when no manifest tables exist."""
+        mock_athena = Mock()
+        mock_glue = Mock()
+
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.side_effect = lambda service, **kw: {
+            "athena": mock_athena,
+            "glue": mock_glue,
+        }[service]
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(
+            bucket="",
+            catalog_url="catalog.example.com",
+            database="test_db",
+            region="us-west-2",
+            iceberg_database="iceberg_db",
+        )
+
+        # Mock Glue to return no matching tables
+        mock_glue.get_tables.return_value = {
+            "TableList": [
+                {"Name": "bucket_a_some_other_table"},
+                {"Name": "bucket_a_package_revision"},
+            ]
+        }
+
+        result = query.find_unique_packages("experiment_id", "EXP-1")
+
+        assert result["packages"] == []
+        assert not result["results"]["errors"]
+
+    @patch("src.package_query.RoleManager")
+    def test_iceberg_build_union_query(self, mock_role_manager_class):
+        """Iceberg UNION ALL query has correct structure."""
+        mock_athena = Mock()
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.return_value = mock_athena
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(
+            bucket="",
+            catalog_url="catalog.example.com",
+            database="test_db",
+            region="us-west-2",
+            iceberg_database="iceberg_db",
+        )
+
+        sql = query._build_iceberg_union_query(
+            ["bucket-a", "bucket-b"],
+            "experiment_id",
+            "EXP-1",
+        )
+
+        # Should reference Iceberg database
+        assert '"iceberg_db".' in sql
+        # Should have UNION ALL
+        assert "UNION ALL" in sql
+        # Should reference both buckets
+        assert "bucket-a" in sql
+        assert "bucket-b" in sql
+        # Should access metadata as STRUCT
+        assert "metadata.experiment_id" in sql
+        # Should have _src_bucket alias
+        assert "_src_bucket" in sql
+        # Should filter on 'latest' tag
+        assert "tag_name = 'latest'" in sql
+        # Should join package_revision + package_manifest + package_tag
+        assert "package_revision" in sql
+        assert "package_manifest" in sql
+        assert "package_tag" in sql
+
+    @patch("src.package_query.RoleManager")
+    def test_iceberg_with_multiple_matches_per_bucket(self, mock_role_manager_class):
+        """Iceberg path handles multiple packages from same bucket."""
+        mock_athena = Mock()
+        mock_glue = Mock()
+
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.side_effect = lambda service, **kw: {
+            "athena": mock_athena,
+            "glue": mock_glue,
+        }[service]
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(
+            bucket="",
+            catalog_url="catalog.example.com",
+            database="test_db",
+            region="us-west-2",
+            iceberg_database="iceberg_db",
+        )
+
+        mock_glue.get_tables.return_value = {
+            "TableList": [
+                {"Name": "bucket_a_package_manifest"},
+            ]
+        }
+
+        query._execute_query = Mock(
+            return_value=[
+                {
+                    "pkg_name": "benchling/pkg-1",
+                    "timestamp": "latest",
+                    "message": "v1",
+                    "user_meta": '{"experiment_id": "EXP-1"}',
+                    "_src_bucket": "bucket-a",
+                },
+                {
+                    "pkg_name": "benchling/pkg-2",
+                    "timestamp": "latest",
+                    "message": "v2",
+                    "user_meta": '{"experiment_id": "EXP-1"}',
+                    "_src_bucket": "bucket-a",
+                },
+            ]
+        )
+
+        result = query.find_unique_packages("experiment_id", "EXP-1")
+
+        assert len(result["packages"]) == 2
+        assert [(p.bucket, p.package_name) for p in result["packages"]] == [
+            ("bucket-a", "benchling/pkg-1"),
+            ("bucket-a", "benchling/pkg-2"),
+        ]

--- a/docker/tests/test_package_query.py
+++ b/docker/tests/test_package_query.py
@@ -309,6 +309,7 @@ class TestPackageQueryIceberg:
 
         query._list_package_view_buckets.assert_called_once()
         assert query._find_unique_packages_in_bucket.call_count == 0  # no buckets to search
+        assert result["packages"] == []
 
     @patch("src.package_query.RoleManager")
     def test_single_bucket_taken_when_bucket_set(self, mock_role_manager_class):
@@ -341,6 +342,7 @@ class TestPackageQueryIceberg:
         result = query.find_unique_packages("experiment_id", "EXP-1")
 
         query._find_unique_packages_in_bucket.assert_called_once_with("my-bucket", "experiment_id", "EXP-1")
+        assert len(result["packages"]) == 1
 
     @patch("src.package_query.RoleManager")
     def test_iceberg_empty_when_no_tables_found(self, mock_role_manager_class):

--- a/docker/tests/test_package_query.py
+++ b/docker/tests/test_package_query.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from src.package_query import PackageQuery
+from src.packages import Package
 
 
 class TestPackageQueryImports:
@@ -139,67 +140,6 @@ class TestPackageQuery:
     def test_find_unique_packages_bucketless_searches_all_package_views(self, mock_role_manager_class):
         """Bucketless PackageQuery searches every discovered package view."""
         mock_athena = Mock()
-        mock_athena.start_query_execution.side_effect = [
-            {"QueryExecutionId": "list-query"},
-            {"QueryExecutionId": "bucket-a-query"},
-            {"QueryExecutionId": "bucket-b-query"},
-        ]
-        mock_athena.get_query_execution.return_value = {"QueryExecution": {"Status": {"State": "SUCCEEDED"}}}
-        mock_athena.get_query_results.side_effect = [
-            {
-                "ResultSet": {
-                    "Rows": [
-                        {"Data": [{"VarCharValue": "table_name"}]},
-                        {"Data": [{"VarCharValue": "bucket-a_packages-view"}]},
-                        {"Data": [{"VarCharValue": "bucket-b_packages-view"}]},
-                    ]
-                }
-            },
-            {
-                "ResultSet": {
-                    "Rows": [
-                        {
-                            "Data": [
-                                {"VarCharValue": "pkg_name"},
-                                {"VarCharValue": "timestamp"},
-                                {"VarCharValue": "message"},
-                                {"VarCharValue": "user_meta"},
-                            ]
-                        },
-                        {
-                            "Data": [
-                                {"VarCharValue": "benchling/pkg-a"},
-                                {"VarCharValue": "latest"},
-                                {"VarCharValue": "A"},
-                                {"VarCharValue": '{"experiment_id": "EXP-1"}'},
-                            ]
-                        },
-                    ]
-                }
-            },
-            {
-                "ResultSet": {
-                    "Rows": [
-                        {
-                            "Data": [
-                                {"VarCharValue": "pkg_name"},
-                                {"VarCharValue": "timestamp"},
-                                {"VarCharValue": "message"},
-                                {"VarCharValue": "user_meta"},
-                            ]
-                        },
-                        {
-                            "Data": [
-                                {"VarCharValue": "benchling/pkg-b"},
-                                {"VarCharValue": "latest"},
-                                {"VarCharValue": "B"},
-                                {"VarCharValue": '{"experiment_id": "EXP-1"}'},
-                            ]
-                        },
-                    ]
-                }
-            },
-        ]
 
         mock_role_manager = Mock()
         mock_session = Mock()
@@ -211,6 +151,24 @@ class TestPackageQuery:
         mock_role_manager_class.return_value = mock_role_manager
 
         query = PackageQuery(bucket="", catalog_url="catalog.example.com", database="test_db")
+        query._list_package_view_buckets = Mock(return_value=["bucket-a", "bucket-b"])
+        query._find_unique_packages_in_bucket = Mock(
+            side_effect=lambda bucket, _key, _value, _timeout=30: {
+                "packages": [Package("catalog.example.com", bucket, f"benchling/pkg-{bucket[-1]}")],
+                "results": {
+                    "rows": [{"pkg_name": f"benchling/pkg-{bucket[-1]}"}],
+                    "package_info": {
+                        f"benchling/pkg-{bucket[-1]}": {
+                            "bucket": bucket,
+                            "versions": [],
+                            "metadata": {"experiment_id": "EXP-1"},
+                            "timestamp": "latest",
+                            "message": bucket[-1].upper(),
+                        }
+                    },
+                },
+            }
+        )
 
         result = query.find_unique_packages("experiment_id", "EXP-1")
 
@@ -218,3 +176,47 @@ class TestPackageQuery:
             ("bucket-a", "benchling/pkg-a"),
             ("bucket-b", "benchling/pkg-b"),
         ]
+        query._list_package_view_buckets.assert_called_once()
+        assert query._find_unique_packages_in_bucket.call_count == 2
+
+    @patch("src.package_query.RoleManager")
+    def test_find_unique_packages_bucketless_continues_after_bucket_error(self, mock_role_manager_class):
+        """Bucketless PackageQuery returns accessible matches even when some bucket views fail."""
+        mock_athena = Mock()
+        mock_role_manager = Mock()
+        mock_session = Mock()
+        mock_session.client.return_value = mock_athena
+        mock_role_manager._get_or_create_session.return_value = (mock_session, None)
+        mock_role_manager.role_arn = None
+        mock_role_manager._session = None
+        mock_role_manager._expires_at = None
+        mock_role_manager_class.return_value = mock_role_manager
+
+        query = PackageQuery(bucket="", catalog_url="catalog.example.com", database="test_db")
+        query._list_package_view_buckets = Mock(return_value=["bucket-a", "bucket-b"])
+
+        def search_bucket(bucket, _key, _value, _timeout=30):
+            if bucket == "bucket-a":
+                raise RuntimeError("Access denied")
+            return {
+                "packages": [Package("catalog.example.com", "bucket-b", "benchling/pkg-b")],
+                "results": {
+                    "rows": [{"pkg_name": "benchling/pkg-b"}],
+                    "package_info": {
+                        "benchling/pkg-b": {
+                            "bucket": "bucket-b",
+                            "versions": [],
+                            "metadata": {"experiment_id": "EXP-1"},
+                            "timestamp": "latest",
+                            "message": "B",
+                        }
+                    },
+                },
+            }
+
+        query._find_unique_packages_in_bucket = Mock(side_effect=search_bucket)
+
+        result = query.find_unique_packages("experiment_id", "EXP-1")
+
+        assert [(pkg.bucket, pkg.package_name) for pkg in result["packages"]] == [("bucket-b", "benchling/pkg-b")]
+        assert result["results"]["errors"] == {"bucket-a": "Access denied"}

--- a/docker/tests/test_pagination.py
+++ b/docker/tests/test_pagination.py
@@ -14,9 +14,7 @@ class TestParseBrowseLinkedButtonIdWithBucket:
     """Tests for the optional '-bucket-' segment parsing."""
 
     def test_no_bucket_segment(self):
-        result = parse_browse_linked_button_id_with_bucket(
-            "browse-linked-etr_123-pkg-benchling--exp-001-p0-s15"
-        )
+        result = parse_browse_linked_button_id_with_bucket("browse-linked-etr_123-pkg-benchling--exp-001-p0-s15")
         assert result == ("etr_123", "benchling/exp-001", None, 0, 15)
 
     def test_valid_bucket_segment(self):
@@ -29,9 +27,7 @@ class TestParseBrowseLinkedButtonIdWithBucket:
         """A package name containing '-bucket-' must not be mis-parsed as a bucket
         suffix when the trailing segment is not a valid S3 bucket name."""
         # Trailing "x" is too short to be a valid bucket name (min 3 chars).
-        result = parse_browse_linked_button_id_with_bucket(
-            "browse-linked-etr_789-pkg-foo--my-bucket-x-p1-s20"
-        )
+        result = parse_browse_linked_button_id_with_bucket("browse-linked-etr_789-pkg-foo--my-bucket-x-p1-s20")
         assert result == ("etr_789", "foo/my-bucket-x", None, 1, 20)
 
 

--- a/docker/tests/test_pagination.py
+++ b/docker/tests/test_pagination.py
@@ -2,7 +2,37 @@
 
 import pytest
 
-from src.pagination import PageState, paginate_items, parse_button_id
+from src.pagination import (
+    PageState,
+    paginate_items,
+    parse_browse_linked_button_id_with_bucket,
+    parse_button_id,
+)
+
+
+class TestParseBrowseLinkedButtonIdWithBucket:
+    """Tests for the optional '-bucket-' segment parsing."""
+
+    def test_no_bucket_segment(self):
+        result = parse_browse_linked_button_id_with_bucket(
+            "browse-linked-etr_123-pkg-benchling--exp-001-p0-s15"
+        )
+        assert result == ("etr_123", "benchling/exp-001", None, 0, 15)
+
+    def test_valid_bucket_segment(self):
+        result = parse_browse_linked_button_id_with_bucket(
+            "browse-linked-etr_456-pkg-benchling--exp-002-bucket-quiltdata-test-p0-s10"
+        )
+        assert result == ("etr_456", "benchling/exp-002", "quiltdata-test", 0, 10)
+
+    def test_bucket_literal_in_package_name_is_not_split(self):
+        """A package name containing '-bucket-' must not be mis-parsed as a bucket
+        suffix when the trailing segment is not a valid S3 bucket name."""
+        # Trailing "x" is too short to be a valid bucket name (min 3 chars).
+        result = parse_browse_linked_button_id_with_bucket(
+            "browse-linked-etr_789-pkg-foo--my-bucket-x-p1-s20"
+        )
+        assert result == ("etr_789", "foo/my-bucket-x", None, 1, 20)
 
 
 class TestPageState:

--- a/docker/uv.lock
+++ b/docker/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "benchling-quilt-integration"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "benchling-sdk" },

--- a/lib/benchling-webhook-stack.ts
+++ b/lib/benchling-webhook-stack.ts
@@ -118,6 +118,12 @@ export class BenchlingWebhookStack extends cdk.Stack {
             allowedValues: ["DEBUG", "INFO", "WARNING", "ERROR"],
         });
 
+        const icebergDatabaseParam = new cdk.CfnParameter(this, "IcebergDatabase", {
+            type: "String",
+            description: "Iceberg Glue database for single-query bucketless search (optional)",
+            default: "",
+        });
+
         const imageTagParam = new cdk.CfnParameter(this, "ImageTag", {
             type: "String",
             description: "Docker image tag to deploy (e.g., latest, 0.7.0, 0.7.0-20251104T123456Z)",
@@ -143,6 +149,7 @@ export class BenchlingWebhookStack extends cdk.Stack {
         const athenaUserWorkgroupValue = athenaUserWorkgroupParam.valueAsString;
         const benchlingSecretValue = benchlingSecretParam.valueAsString;
         const logLevelValue = logLevelParam.valueAsString;
+        const icebergDatabaseValue = icebergDatabaseParam.valueAsString;
         const imageTagValue = imageTagParam.valueAsString;
         const packageBucketValue = packageBucketParam.valueAsString;
         const quiltDatabaseValue = quiltDatabaseParam.valueAsString;
@@ -329,6 +336,7 @@ export class BenchlingWebhookStack extends cdk.Stack {
             packageBucket: packageBucketValue,
             quiltDatabase: quiltDatabaseValue,
             logLevel: logLevelValue,
+            icebergDatabase: icebergDatabaseValue,
         });
 
         // Create REST API v1 that routes through VPC Link to the NLB

--- a/lib/benchling-webhook-stack.ts
+++ b/lib/benchling-webhook-stack.ts
@@ -121,7 +121,7 @@ export class BenchlingWebhookStack extends cdk.Stack {
         const icebergDatabaseParam = new cdk.CfnParameter(this, "IcebergDatabase", {
             type: "String",
             description: "Iceberg Glue database for single-query bucketless search (optional)",
-            default: "",
+            default: config.quilt.icebergDatabase || "",
         });
 
         const imageTagParam = new cdk.CfnParameter(this, "ImageTag", {

--- a/lib/configuration-validator.ts
+++ b/lib/configuration-validator.ts
@@ -48,7 +48,6 @@ export class ConfigurationValidator {
         "benchlingClientId",
         "benchlingClientSecret",
         "benchlingAppDefinitionId",
-        "quiltUserBucket",
         "quiltRegion",
     ];
 

--- a/lib/fargate-service.ts
+++ b/lib/fargate-service.ts
@@ -218,16 +218,28 @@ export class FargateService extends Construct {
         );
 
         // Grant Glue access for Quilt catalog tables and optional Iceberg package tables.
-        // The Iceberg database is a CloudFormation parameter, so include it in
-        // the policy resources even when the default is empty; deployed stacks
-        // with a non-empty parameter receive the matching table grants.
+        // The Iceberg database is a CloudFormation parameter (token), so gate the
+        // Iceberg grants behind a condition: when the parameter is empty, drop them
+        // entirely rather than synthesizing invalid `database/` / `table//*` ARNs
+        // (which would break deployment in the common "no Iceberg" case).
         const region = config.deployment.region;
+        const hasIcebergDatabase = new cdk.CfnCondition(this, "HasIcebergDatabase", {
+            expression: cdk.Fn.conditionNot(cdk.Fn.conditionEquals(props.icebergDatabase || "", "")),
+        });
         const glueResources = [
             `arn:aws:glue:${region}:*:catalog`,
             `arn:aws:glue:${region}:*:database/${props.quiltDatabase}`,
             `arn:aws:glue:${region}:*:table/${props.quiltDatabase}/*`,
-            `arn:aws:glue:${region}:*:database/${props.icebergDatabase || ""}`,
-            `arn:aws:glue:${region}:*:table/${props.icebergDatabase || ""}/*`,
+            cdk.Fn.conditionIf(
+                hasIcebergDatabase.logicalId,
+                `arn:aws:glue:${region}:*:database/${props.icebergDatabase}`,
+                cdk.Aws.NO_VALUE,
+            ).toString(),
+            cdk.Fn.conditionIf(
+                hasIcebergDatabase.logicalId,
+                `arn:aws:glue:${region}:*:table/${props.icebergDatabase}/*`,
+                cdk.Aws.NO_VALUE,
+            ).toString(),
         ];
         taskRole.addToPolicy(
             new iam.PolicyStatement({

--- a/lib/fargate-service.ts
+++ b/lib/fargate-service.ts
@@ -217,20 +217,27 @@ export class FargateService extends Construct {
             }),
         );
 
-        // Grant Glue access for the specific Quilt database
+        // Grant Glue access for Quilt catalog tables and optional Iceberg package tables.
+        // The Iceberg database is a CloudFormation parameter, so include it in
+        // the policy resources even when the default is empty; deployed stacks
+        // with a non-empty parameter receive the matching table grants.
         const region = config.deployment.region;
+        const glueResources = [
+            `arn:aws:glue:${region}:*:catalog`,
+            `arn:aws:glue:${region}:*:database/${props.quiltDatabase}`,
+            `arn:aws:glue:${region}:*:table/${props.quiltDatabase}/*`,
+            `arn:aws:glue:${region}:*:database/${props.icebergDatabase || ""}`,
+            `arn:aws:glue:${region}:*:table/${props.icebergDatabase || ""}/*`,
+        ];
         taskRole.addToPolicy(
             new iam.PolicyStatement({
                 actions: [
                     "glue:GetDatabase",
                     "glue:GetTable",
+                    "glue:GetTables",
                     "glue:GetPartitions",
                 ],
-                resources: [
-                    `arn:aws:glue:${region}:*:catalog`,
-                    `arn:aws:glue:${region}:*:database/${props.quiltDatabase}`,
-                    `arn:aws:glue:${region}:*:table/${props.quiltDatabase}/*`,
-                ],
+                resources: glueResources,
             }),
         );
 

--- a/lib/fargate-service.ts
+++ b/lib/fargate-service.ts
@@ -48,6 +48,7 @@ export interface FargateServiceProps {
     readonly packageBucket?: string;
     readonly quiltDatabase: string;
     readonly logLevel?: string;
+    readonly icebergDatabase?: string;
 }
 
 export class FargateService extends Construct {
@@ -302,6 +303,9 @@ export class FargateService extends Construct {
             // Application Configuration
             APP_ENV: "production",
             LOG_LEVEL: props.logLevel || "INFO",  // StackConfig doesn't include logging level - use parameter default
+
+            // Optional Iceberg database for bucketless search (v0.19.0+)
+            QUILT_ICEBERG_DATABASE: props.icebergDatabase || "",
         };
 
         if (props.packageEventQueue) {

--- a/lib/fargate-service.ts
+++ b/lib/fargate-service.ts
@@ -45,7 +45,7 @@ export interface FargateServiceProps {
 
     // Runtime-configurable parameters (from CloudFormation)
     readonly benchlingSecret: string;
-    readonly packageBucket: string;
+    readonly packageBucket?: string;
     readonly quiltDatabase: string;
     readonly logLevel?: string;
 }
@@ -147,33 +147,35 @@ export class FargateService extends Construct {
             }),
         );
 
-        // Grant S3 access for the specific package bucket
-        // Full Quilt-required permissions for versioned S3 objects
-        const packageBucketArn = `arn:aws:s3:::${props.packageBucket}`;
-        taskRole.addToPolicy(
-            new iam.PolicyStatement({
-                actions: [
-                    "s3:GetObject",
-                    "s3:GetObjectAttributes",
-                    "s3:GetObjectTagging",
-                    "s3:GetObjectVersion",
-                    "s3:GetObjectVersionAttributes",
-                    "s3:GetObjectVersionTagging",
-                    "s3:ListBucket",
-                    "s3:ListBucketVersions",
-                    "s3:DeleteObject",
-                    "s3:DeleteObjectVersion",
-                    "s3:PutObject",
-                    "s3:PutObjectTagging",
-                    "s3:GetBucketNotification",
-                    "s3:PutBucketNotification",
-                ],
-                resources: [
-                    packageBucketArn,
-                    `${packageBucketArn}/*`,
-                ],
-            }),
-        );
+        if (props.packageBucket) {
+            // Grant S3 access for the specific package bucket
+            // Full Quilt-required permissions for versioned S3 objects
+            const packageBucketArn = `arn:aws:s3:::${props.packageBucket}`;
+            taskRole.addToPolicy(
+                new iam.PolicyStatement({
+                    actions: [
+                        "s3:GetObject",
+                        "s3:GetObjectAttributes",
+                        "s3:GetObjectTagging",
+                        "s3:GetObjectVersion",
+                        "s3:GetObjectVersionAttributes",
+                        "s3:GetObjectVersionTagging",
+                        "s3:ListBucket",
+                        "s3:ListBucketVersions",
+                        "s3:DeleteObject",
+                        "s3:DeleteObjectVersion",
+                        "s3:PutObject",
+                        "s3:PutObjectTagging",
+                        "s3:GetBucketNotification",
+                        "s3:PutBucketNotification",
+                    ],
+                    resources: [
+                        packageBucketArn,
+                        `${packageBucketArn}/*`,
+                    ],
+                }),
+            );
+        }
 
         // Attach Quilt managed policies directly to task role
         // This eliminates the need for role assumption and trust policy coordination

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -250,6 +250,17 @@ export interface QuiltConfig {
      * @example "arn:aws:iam::123456789012:policy/quilt-staging-UserAthenaNonManagedRolePolicy-XXXXX"
      */
     athenaUserPolicyArn?: string;
+
+    /**
+     * Iceberg Glue database for single-query bucketless search (optional)
+     *
+     * When set, bucketless PackageQuery searches Iceberg manifest tables instead
+     * of fanning out concurrent Athena queries. Passed to container as
+     * QUILT_ICEBERG_DATABASE.
+     *
+     * @example "icebergdatabase-v9cxuqnwjj5a"
+     */
+    icebergDatabase?: string;
 }
 
 /**

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -310,11 +310,15 @@ export interface BenchlingConfig {
  */
 export interface PackageConfig {
     /**
-     * S3 bucket for package storage
+     * S3 bucket for package storage.
+     *
+     * When omitted, the webhook runs in bucketless mode: it does not create
+     * default packages for unlinked entries and linked-package lookup is not
+     * scoped to a single configured bucket.
      *
      * @example "benchling-packages"
      */
-    bucket: string;
+    bucket?: string;
 
     /**
      * S3 key prefix for packages
@@ -760,7 +764,7 @@ export const ProfileConfigSchema = {
         },
         packages: {
             type: "object",
-            required: ["bucket", "prefix", "metadataKey"],
+            required: ["prefix", "metadataKey"],
             properties: {
                 bucket: { type: "string", minLength: 3 },
                 prefix: { type: "string", minLength: 1 },

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -759,6 +759,7 @@ export const ProfileConfigSchema = {
                 athenaUserWorkgroup: { type: "string", minLength: 1 },
                 bucketWritePolicyArn: { type: "string", pattern: "^arn:aws:iam::\\d{12}:policy/.+" },
                 athenaUserPolicyArn: { type: "string", pattern: "^arn:aws:iam::\\d{12}:policy/.+" },
+                icebergDatabase: { type: "string", minLength: 1 },
             },
         },
         benchling: {

--- a/lib/types/stack-config.ts
+++ b/lib/types/stack-config.ts
@@ -135,6 +135,16 @@ export interface StackConfig {
          * @example "arn:aws:iam::123456789012:policy/quilt-staging-UserAthenaNonManagedRolePolicy-XXXXX"
          */
         athenaUserPolicyArn?: string;
+
+        /**
+         * Iceberg Glue database for single-query bucketless linked-package search (optional)
+         *
+         * Passed to the container as QUILT_ICEBERG_DATABASE and used by the
+         * stack to grant Glue access for Iceberg package metadata tables.
+         *
+         * @example "icebergdatabase-v9cxuqnwjj5a"
+         */
+        icebergDatabase?: string;
     };
 
     /**

--- a/lib/utils/config-transform.ts
+++ b/lib/utils/config-transform.ts
@@ -25,7 +25,7 @@ import type { StackConfig } from "../types/stack-config";
  *
  * **Transformation logic:**
  * - Benchling: Only secretArn (credentials stored in secret)
- * - Quilt: Service endpoints (catalog, database, queueUrl, region, bucketWritePolicyArn, athenaUserPolicyArn)
+ * - Quilt: Service endpoints (catalog, database, queueUrl, region, bucketWritePolicyArn, athenaUserPolicyArn, icebergDatabase)
  * - Deployment: Infrastructure settings (region, imageTag, vpc, stackName)
  * - Security: Optional IP allowlist
  *
@@ -83,6 +83,9 @@ export function profileToStackConfig(
     }
     if (profile.quilt.athenaUserPolicyArn) {
         stackConfig.quilt.athenaUserPolicyArn = profile.quilt.athenaUserPolicyArn;
+    }
+    if (profile.quilt.icebergDatabase) {
+        stackConfig.quilt.icebergDatabase = profile.quilt.icebergDatabase;
     }
 
     // Deployment image tag

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -202,7 +202,6 @@ export function validateConfig(config: Partial<Config>): ValidationResult {
     // Required user-provided values (CANNOT be inferred)
     const requiredUserFields: Array<[keyof Config, string, string]> = [
         ["quiltCatalog", "Quilt catalog URL", "Your Quilt catalog domain (e.g., quilt-catalog.company.com)"],
-        ["quiltUserBucket", "S3 bucket for data", "Optional. When omitted, bucketless mode searches linked packages without creating default packages."],
         ["benchlingTenant", "Benchling tenant", "Your Benchling tenant name (use XXX if you login to XXX.benchling.com)"],
         ["benchlingClientId", "Benchling OAuth client ID", "OAuth client ID from your Benchling app"],
         ["benchlingClientSecret", "Benchling OAuth client secret", "OAuth client secret from your Benchling app"],

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -202,7 +202,7 @@ export function validateConfig(config: Partial<Config>): ValidationResult {
     // Required user-provided values (CANNOT be inferred)
     const requiredUserFields: Array<[keyof Config, string, string]> = [
         ["quiltCatalog", "Quilt catalog URL", "Your Quilt catalog domain (e.g., quilt-catalog.company.com)"],
-        ["quiltUserBucket", "S3 bucket for data", "The S3 bucket where you want to store Benchling exports (CANNOT be inferred - must be explicitly provided)"],
+        ["quiltUserBucket", "S3 bucket for data", "Optional. When omitted, bucketless mode searches linked packages without creating default packages."],
         ["benchlingTenant", "Benchling tenant", "Your Benchling tenant name (use XXX if you login to XXX.benchling.com)"],
         ["benchlingClientId", "Benchling OAuth client ID", "OAuth client ID from your Benchling app"],
         ["benchlingClientSecret", "Benchling OAuth client secret", "OAuth client secret from your Benchling app"],

--- a/lib/utils/service-resolver.ts
+++ b/lib/utils/service-resolver.ts
@@ -43,6 +43,12 @@ export interface QuiltServices {
      * @example "quilt-user-workgroup"
      */
     athenaUserWorkgroup?: string;
+
+    /**
+     * Iceberg Glue database for single-query bucketless search (optional)
+     * @example "icebergdatabase-v9cxuqnwjj5a"
+     */
+    icebergDatabase?: string;
 }
 
 /**
@@ -183,6 +189,7 @@ export function validateQueueUrl(url: string): boolean {
  *
  * **Optional Stack Outputs**:
  * - `UserAthenaWorkgroupName`: Athena workgroup for user queries
+ * - `IcebergDatabase`/`IcebergDatabaseName`: Iceberg Glue database for package metadata
  *
  * @param options - Service resolver options
  * @returns Resolved service endpoints
@@ -279,11 +286,13 @@ export async function resolveQuiltServices(
 
     // Step 6: Extract optional Athena resources (NEW - from Quilt stack discovery)
     const athenaUserWorkgroup = outputs.UserAthenaWorkgroupName;
+    const icebergDatabase = outputs.IcebergDatabase || outputs.IcebergDatabaseName;
 
     return {
         packagerQueueUrl,
         athenaUserDatabase,
         quiltWebHost,
         ...(athenaUserWorkgroup && { athenaUserWorkgroup }),
+        ...(icebergDatabase && { icebergDatabase }),
     };
 }

--- a/lib/utils/stack-inference.ts
+++ b/lib/utils/stack-inference.ts
@@ -64,12 +64,14 @@ export interface StackResourceMap {
  * - BenchlingAthenaWorkgroup (AWS::Athena::WorkGroup)
  * - UserAthenaNonManagedRolePolicy (AWS::IAM::ManagedPolicy)
  * - BucketWritePolicy (AWS::IAM::ManagedPolicy)
+ * - IcebergDatabase (AWS::Glue::Database)
  * - BenchlingSecret (AWS::SecretsManager::Secret)
  */
 export interface DiscoveredQuiltResources {
     athenaUserWorkgroup?: string;
     athenaUserPolicyArn?: string;
     bucketWritePolicyArn?: string;
+    icebergDatabase?: string;
     benchlingSecretArn?: string;
 }
 
@@ -155,6 +157,7 @@ export function toRoleArn(roleNameOrArn: string, account: string): string {
  * - BenchlingAthenaWorkgroup (AWS::Athena::WorkGroup)
  * - UserAthenaNonManagedRolePolicy (AWS::IAM::ManagedPolicy)
  * - BucketWritePolicy (AWS::IAM::ManagedPolicy)
+ * - IcebergDatabase (AWS::Glue::Database)
  * - BenchlingSecret (AWS::SecretsManager::Secret)
  *
  * @param resources Stack resource map from getStackResources
@@ -172,6 +175,7 @@ export function extractQuiltResources(
         BenchlingAthenaWorkgroup: "athenaUserWorkgroup",
         UserAthenaNonManagedRolePolicy: "athenaUserPolicyArn",
         BucketWritePolicy: "bucketWritePolicyArn",
+        IcebergDatabase: "icebergDatabase",
         BenchlingSecret: "benchlingSecretArn",
     };
 
@@ -463,6 +467,13 @@ export function buildInferredConfig(
         // Infer database name from catalog (common pattern)
         const dbGuess = catalog.replace(/[.-]/g, "_") + "_db";
         vars.QUILT_DATABASE = `${dbGuess} # VERIFY THIS - inferred from catalog name`;
+    }
+
+    const icebergDatabaseOutput = stackDetails.outputs.find(
+        (o) => o.OutputKey === "IcebergDatabase" || o.OutputKey === "IcebergDatabaseName",
+    );
+    if (icebergDatabaseOutput?.OutputValue) {
+        vars.QUILT_ICEBERG_DATABASE = icebergDatabaseOutput.OutputValue;
     }
 
     // SQS Queue URL (normalize from URL or ARN)

--- a/lib/wizard/phase2-stack-query.ts
+++ b/lib/wizard/phase2-stack-query.ts
@@ -80,6 +80,7 @@ export async function runStackQuery(
         const athenaUserWorkgroup = inferenceResult.athenaUserWorkgroup;
         const bucketWritePolicyArn = inferenceResult.bucketWritePolicyArn;
         const athenaUserPolicyArn = inferenceResult.athenaUserPolicyArn;
+        const icebergDatabase = inferenceResult.icebergDatabase;
 
         // Show IAM managed policies (these are logged by inferQuiltConfig)
         if (bucketWritePolicyArn) {
@@ -87,6 +88,9 @@ export async function runStackQuery(
         }
         if (athenaUserPolicyArn) {
             console.log(chalk.dim(`✓ UserAthenaNonManagedRolePolicy discovered: ${athenaUserPolicyArn}`));
+        }
+        if (icebergDatabase) {
+            console.log(chalk.dim(`✓ IcebergDatabase discovered: ${icebergDatabase}`));
         }
 
         // Log what we found
@@ -96,6 +100,7 @@ export async function runStackQuery(
         console.log(chalk.dim(`✓ Region: ${region}`));
         console.log(chalk.dim(`✓ Queue URL: ${queueUrl}`));
         console.log(chalk.dim(`✓ Database: ${database}`));
+        console.log(chalk.dim(`✓ Iceberg Database: ${icebergDatabase || "(not configured)"}`));
         console.log(chalk.dim(`✓ Workgroup: ${athenaUserWorkgroup}`));
         console.log(athenaUserPolicyArn
             ? chalk.dim(`✓ Athena User Policy: ${athenaUserPolicyArn}`)
@@ -202,6 +207,7 @@ export async function runStackQuery(
             athenaUserWorkgroup,
             bucketWritePolicyArn,
             athenaUserPolicyArn,
+            icebergDatabase,
             discoveredVpc: discoveredVpcInfo,
             stackQuerySucceeded: true,
         };

--- a/lib/wizard/phase3-parameter-collection.ts
+++ b/lib/wizard/phase3-parameter-collection.ts
@@ -312,7 +312,7 @@ export async function runParameterCollection(
     // =========================================================================
     console.log("\n" + chalk.cyan("Package Configuration:"));
 
-    let bucket: string;
+    let bucket: string | undefined;
     let prefix: string;
     let metadataKey: string;
     let workflow: string | undefined;
@@ -327,17 +327,13 @@ export async function runParameterCollection(
         console.log(`  Metadata Key: ${metadataKey} (from CLI)`);
         console.log(`  Workflow: ${workflow || "(default)"} (from ${input.workflow !== undefined ? "CLI" : "default"})`);
     } else if (yes) {
-        // In non-interactive mode, use CLI args or existing config or error
-        bucket = input.userBucket || existingConfig?.packages?.bucket || "";
+        // In non-interactive mode, use CLI args or existing config. Empty means bucketless mode.
+        bucket = input.userBucket || existingConfig?.packages?.bucket || undefined;
         prefix = input.pkgPrefix || existingConfig?.packages?.prefix || "benchling";
         metadataKey = input.pkgKey || existingConfig?.packages?.metadataKey || "experiment_id";
         workflow = input.workflow?.trim() || existingConfig?.packages?.workflow || undefined;
 
-        if (!bucket) {
-            throw new Error("--user-bucket is required in non-interactive mode");
-        }
-
-        console.log(`  Bucket: ${bucket} (from ${input.userBucket ? "CLI" : "existing config"})`);
+        console.log(`  Bucket: ${bucket || "(bucketless mode)"} (from ${input.userBucket ? "CLI" : existingConfig?.packages?.bucket ? "existing config" : "default"})`);
         console.log(`  Prefix: ${prefix} (from ${input.pkgPrefix ? "CLI" : existingConfig?.packages?.prefix ? "existing config" : "default"})`);
         console.log(`  Metadata Key: ${metadataKey} (from ${input.pkgKey ? "CLI" : existingConfig?.packages?.metadataKey ? "existing config" : "default"})`);
         console.log(`  Workflow: ${workflow || "(default)"} (from ${input.workflow !== undefined ? "CLI" : existingConfig?.packages?.workflow ? "existing config" : "default"})`);
@@ -347,10 +343,8 @@ export async function runParameterCollection(
             {
                 type: "input",
                 name: "bucket",
-                message: "Package S3 Bucket:",
+                message: "Package S3 Bucket (optional, empty for bucketless mode):",
                 default: existingConfig?.packages?.bucket || "",
-                validate: (value: string): boolean | string =>
-                    value.trim().length > 0 || "Bucket name is required",
             },
             {
                 type: "input",
@@ -371,7 +365,7 @@ export async function runParameterCollection(
                 default: existingConfig?.packages?.workflow || "",
             },
         ]);
-        bucket = packageAnswers.bucket;
+        bucket = packageAnswers.bucket.trim() || undefined;
         prefix = packageAnswers.prefix;
         metadataKey = packageAnswers.metadataKey;
         workflow = packageAnswers.workflow.trim() || undefined;
@@ -446,7 +440,7 @@ export async function runParameterCollection(
             appDefinitionId,
         },
         packages: {
-            bucket,
+            ...(bucket ? { bucket } : {}),
             prefix,
             metadataKey,
             workflow,

--- a/lib/wizard/phase3-parameter-collection.ts
+++ b/lib/wizard/phase3-parameter-collection.ts
@@ -343,7 +343,9 @@ export async function runParameterCollection(
             {
                 type: "input",
                 name: "bucket",
-                message: "Package S3 Bucket (optional, empty for bucketless mode):",
+                message: existingConfig?.packages?.bucket
+                    ? "Package S3 Bucket (Enter keeps current, '-' clears to bucketless mode):"
+                    : "Package S3 Bucket (optional, empty for bucketless mode):",
                 default: existingConfig?.packages?.bucket || "",
             },
             {
@@ -365,7 +367,11 @@ export async function runParameterCollection(
                 default: existingConfig?.packages?.workflow || "",
             },
         ]);
-        bucket = packageAnswers.bucket.trim() || undefined;
+        // "-" is an explicit sentinel to clear a previously-configured bucket
+        // (bucketless mode). inquirer returns the default on empty input, so a
+        // sentinel is the only way to unset an existing value from the wizard.
+        const bucketInput = packageAnswers.bucket.trim();
+        bucket = bucketInput === "-" ? undefined : bucketInput || undefined;
         prefix = packageAnswers.prefix;
         metadataKey = packageAnswers.metadataKey;
         workflow = packageAnswers.workflow.trim() || undefined;

--- a/lib/wizard/phase4-validation.ts
+++ b/lib/wizard/phase4-validation.ts
@@ -283,17 +283,19 @@ export async function runValidation(input: ValidationInput): Promise<ValidationR
     }
     result.warnings.push(...credValidation.warnings);
 
-    // Validate S3 bucket access
-    const bucketValidation = await validateS3BucketAccess(
-        parameters.packages.bucket,
-        parameters.deployment.region,
-        awsProfile,
-    );
-    if (!bucketValidation.isValid) {
-        result.success = false;
-        result.errors.push(...bucketValidation.errors);
+    // Validate S3 bucket access only when a bucket is configured.
+    if (parameters.packages.bucket) {
+        const bucketValidation = await validateS3BucketAccess(
+            parameters.packages.bucket,
+            parameters.deployment.region,
+            awsProfile,
+        );
+        if (!bucketValidation.isValid) {
+            result.success = false;
+            result.errors.push(...bucketValidation.errors);
+        }
+        result.warnings.push(...bucketValidation.warnings);
     }
-    result.warnings.push(...bucketValidation.warnings);
 
     if (result.success) {
         console.log(chalk.green("✓ Configuration validated successfully\n"));
@@ -302,7 +304,7 @@ export async function runValidation(input: ValidationInput): Promise<ValidationR
         console.error(chalk.gray("   The following validations were performed:"));
         console.error(chalk.gray(`   - Benchling tenant: ${parameters.benchling.tenant}`));
         console.error(chalk.gray(`   - OAuth credentials: Client ID ${parameters.benchling.clientId.substring(0, 8)}...`));
-        console.error(chalk.gray(`   - S3 bucket: ${parameters.packages.bucket} (region: ${parameters.deployment.region})`));
+        console.error(chalk.gray(`   - S3 bucket: ${parameters.packages.bucket || "(bucketless mode)"} (region: ${parameters.deployment.region})`));
         console.error("");
         result.errors.forEach((err) => console.error(`${err}\n`));
     }

--- a/lib/wizard/phase6-integrated-mode.ts
+++ b/lib/wizard/phase6-integrated-mode.ts
@@ -38,7 +38,7 @@ function buildProfileConfig(input: IntegratedModeInput): ProfileConfig {
             secretArn: benchlingSecretArn,
         },
         packages: {
-            bucket: parameters.packages.bucket,
+            ...(parameters.packages.bucket ? { bucket: parameters.packages.bucket } : {}),
             prefix: parameters.packages.prefix,
             metadataKey: parameters.packages.metadataKey,
         },

--- a/lib/wizard/phase7-standalone-mode.ts
+++ b/lib/wizard/phase7-standalone-mode.ts
@@ -38,7 +38,7 @@ function buildProfileConfig(input: StandaloneModeInput): ProfileConfig {
             // No secretArn yet - will be set after creating secret
         },
         packages: {
-            bucket: parameters.packages.bucket,
+            ...(parameters.packages.bucket ? { bucket: parameters.packages.bucket } : {}),
             prefix: parameters.packages.prefix,
             metadataKey: parameters.packages.metadataKey,
         },

--- a/lib/wizard/profile-config-builder.ts
+++ b/lib/wizard/profile-config-builder.ts
@@ -70,7 +70,7 @@ export function buildProfileConfigFromParameters(input: ConfigFromParametersInpu
             ...(benchlingSecretArn ? { secretArn: benchlingSecretArn } : {}),
         },
         packages: {
-            bucket: parameters.packages.bucket,
+            ...(parameters.packages.bucket ? { bucket: parameters.packages.bucket } : {}),
             prefix: parameters.packages.prefix,
             metadataKey: parameters.packages.metadataKey,
             ...(parameters.packages.workflow ? { workflow: parameters.packages.workflow } : {}),
@@ -120,10 +120,6 @@ export function buildProfileConfigFromExisting(input: ConfigFromExistingInput): 
         throw new Error("Missing Benchling credentials in existing configuration or secret");
     }
 
-    if (!packages.bucket) {
-        throw new Error("Missing package bucket in existing configuration or secret");
-    }
-
     const vpcFromStack = stackQuery.discoveredVpc?.isValid
         ? {
             vpcId: stackQuery.discoveredVpc.vpcId,
@@ -143,7 +139,7 @@ export function buildProfileConfigFromExisting(input: ConfigFromExistingInput): 
     };
 
     const packagesConfig = {
-        bucket: packages.bucket!,
+        ...(packages.bucket ? { bucket: packages.bucket } : {}),
         prefix: packages.prefix,
         metadataKey: packages.metadataKey,
         ...(existingConfig?.packages?.workflow ?? secretDetails?.workflow

--- a/lib/wizard/profile-config-builder.ts
+++ b/lib/wizard/profile-config-builder.ts
@@ -46,6 +46,9 @@ function applyDiscoveredResources(config: ProfileConfig, stackQuery: StackQueryR
     if (stackQuery.athenaUserPolicyArn) {
         config.quilt.athenaUserPolicyArn = stackQuery.athenaUserPolicyArn;
     }
+    if (stackQuery.icebergDatabase) {
+        config.quilt.icebergDatabase = stackQuery.icebergDatabase;
+    }
 }
 
 /**
@@ -157,6 +160,7 @@ export function buildProfileConfigFromExisting(input: ConfigFromExistingInput): 
             athenaUserWorkgroup: existingConfig?.quilt?.athenaUserWorkgroup,
             bucketWritePolicyArn: existingConfig?.quilt?.bucketWritePolicyArn,
             athenaUserPolicyArn: existingConfig?.quilt?.athenaUserPolicyArn,
+            icebergDatabase: existingConfig?.quilt?.icebergDatabase,
         },
         benchling: benchlingConfig,
         packages: packagesConfig,

--- a/lib/wizard/types.ts
+++ b/lib/wizard/types.ts
@@ -76,6 +76,8 @@ export interface StackQueryResult {
     bucketWritePolicyArn?: string;
     /** IAM managed policy ARN for Athena query access (from UserAthenaNonManagedRolePolicy) */
     athenaUserPolicyArn?: string;
+    /** Iceberg Glue database for single-query bucketless search (from IcebergDatabase) */
+    icebergDatabase?: string;
     /** Discovered VPC from Quilt stack (optional) */
     discoveredVpc?: DiscoveredVpcInfo;
 }

--- a/lib/wizard/types.ts
+++ b/lib/wizard/types.ts
@@ -129,7 +129,7 @@ export interface ParameterCollectionResult {
         appDefinitionId: string;
     };
     packages: {
-        bucket: string;
+        bucket?: string;
         prefix: string;
         metadataKey: string;
         workflow?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quiltdata/benchling-webhook",
-  "version": "0.16.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@quiltdata/benchling-webhook",
-      "version": "0.16.0",
+      "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.953.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quiltdata/benchling-webhook",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "AWS CDK deployment for Benchling webhook processing using Fargate - Deploy directly with npx",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/scripts/check-iceberg-search.sh
+++ b/scripts/check-iceberg-search.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# check-iceberg-search.sh — Probe the bucketless Iceberg package search end-to-end.
+#
+# Reproduces exactly what the container's PackageQuery._build_iceberg_union_query
+# runs when refreshing a bucketless canvas, so you can confirm (outside the
+# service) that:
+#   1. the Iceberg package_manifest tables exist,
+#   2. the `metadata` column is a JSON *string* (not a native STRUCT), and
+#   3. the json_extract_scalar filter returns the expected linked package.
+#
+# Background: metadata is populated from `user_meta AS metadata`
+# (quilt_shared.iceberg_queries), i.e. a raw JSON string. Filtering it as a
+# STRUCT (`m.metadata.<key>`) raises:
+#     TYPE_MISMATCH: Expression m.metadata is not of type ROW
+# which surfaces in the canvas as "Failed to search for linked packages".
+# This script verifies the json_extract_scalar form that avoids that.
+#
+# Config is read from the profile at ~/.config/benchling-webhook/<profile>/config.json
+# (quilt.database is used as the Iceberg Glue database, matching the CDK default).
+#
+# Usage:
+#   scripts/check-iceberg-search.sh --value EXP26000016
+#   scripts/check-iceberg-search.sh --profile bucketless --value EXP26000016
+#   scripts/check-iceberg-search.sh --profile bucketless --key experiment_id --value EXP26000016
+#   scripts/check-iceberg-search.sh --profile bucketless --value EXP26000016 --show-buggy
+#
+# Options:
+#   --profile <name>   Profile under ~/.config/benchling-webhook (default: default)
+#   --key <name>       Metadata key to filter on (default: packages.metadataKey from config)
+#   --value <val>      Metadata value to match (required)
+#   --database <name>  Override Iceberg Glue database (default: quilt.database from config)
+#   --region <name>    Override AWS region (default: quilt.region from config)
+#   --workgroup <name> Override Athena workgroup (default: quilt.athenaUserWorkgroup from config)
+#   --show-buggy       Also run the old STRUCT-access form to demonstrate the failure
+#
+set -euo pipefail
+
+PROFILE="default"
+KEY=""
+VALUE=""
+DATABASE=""
+REGION=""
+WORKGROUP=""
+SHOW_BUGGY="false"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --profile)   PROFILE="$2"; shift 2 ;;
+        --key)       KEY="$2"; shift 2 ;;
+        --value)     VALUE="$2"; shift 2 ;;
+        --database)  DATABASE="$2"; shift 2 ;;
+        --region)    REGION="$2"; shift 2 ;;
+        --workgroup) WORKGROUP="$2"; shift 2 ;;
+        --show-buggy) SHOW_BUGGY="true"; shift ;;
+        -h|--help)   grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+CONFIG="$HOME/.config/benchling-webhook/$PROFILE/config.json"
+if [[ ! -f "$CONFIG" ]]; then
+    echo "ERROR: profile config not found: $CONFIG" >&2
+    exit 1
+fi
+
+# Read a dotted path from the profile config.json.
+cfg() { python3 -c "import json,sys; d=json.load(open('$CONFIG'));
+p='$1'.split('.'); v=d
+for k in p:
+    v = v.get(k, '') if isinstance(v, dict) else ''
+print(v if v is not None else '')"; }
+
+DATABASE="${DATABASE:-$(cfg quilt.database)}"
+REGION="${REGION:-$(cfg quilt.region)}"
+WORKGROUP="${WORKGROUP:-$(cfg quilt.athenaUserWorkgroup)}"
+KEY="${KEY:-$(cfg packages.metadataKey)}"
+CATALOG="$(cfg quilt.catalog)"
+
+if [[ -z "$VALUE" ]]; then
+    echo "ERROR: --value is required (the metadata value to search for)" >&2
+    exit 1
+fi
+if [[ -z "$DATABASE" || -z "$REGION" || -z "$WORKGROUP" || -z "$KEY" ]]; then
+    echo "ERROR: could not resolve database/region/workgroup/key from $CONFIG" >&2
+    echo "  database=$DATABASE region=$REGION workgroup=$WORKGROUP key=$KEY" >&2
+    exit 1
+fi
+
+echo "profile:   $PROFILE"
+echo "catalog:   $CATALOG"
+echo "database:  $DATABASE (Iceberg Glue database)"
+echo "region:    $REGION"
+echo "workgroup: $WORKGROUP"
+echo "filter:    $KEY = $VALUE"
+echo
+
+# --- 1. Discover per-bucket Iceberg manifest tables -------------------------
+echo "### Iceberg package_manifest tables"
+MANIFESTS=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && MANIFESTS+=("$line")
+done < <(aws glue get-tables \
+    --database-name "$DATABASE" --region "$REGION" \
+    --query 'TableList[?ends_with(Name, `_package_manifest`)].Name' \
+    --output text 2>/dev/null | tr '\t' '\n' || true)
+
+if [[ ${#MANIFESTS[@]} -eq 0 ]]; then
+    echo "  (none found — is this a bucketless/Iceberg deployment?)" >&2
+    exit 1
+fi
+printf '  %s\n' "${MANIFESTS[@]}"
+echo
+
+# --- 2. Confirm the metadata column type ------------------------------------
+FIRST_MANIFEST="${MANIFESTS[0]}"
+echo "### metadata column type on $FIRST_MANIFEST"
+META_TYPE="$(aws glue get-table \
+    --database-name "$DATABASE" --name "$FIRST_MANIFEST" --region "$REGION" \
+    --query "Table.StorageDescriptor.Columns[?Name=='metadata'].Type | [0]" \
+    --output text 2>/dev/null)"
+echo "  metadata: $META_TYPE"
+if [[ "$META_TYPE" == "string" ]]; then
+    echo "  -> JSON string: MUST use json_extract_scalar (STRUCT access would TYPE_MISMATCH)"
+else
+    echo "  -> WARNING: expected 'string'; schema may have changed"
+fi
+echo
+
+# --- Athena query runner ----------------------------------------------------
+run_query() {
+    local label="$1" query="$2"
+    echo "### $label"
+    local qid
+    qid=$(aws athena start-query-execution --region "$REGION" --work-group "$WORKGROUP" \
+        --query-execution-context Database="$DATABASE" \
+        --query-string "$query" --query 'QueryExecutionId' --output text)
+    local state=""
+    for _ in $(seq 1 120); do
+        state=$(aws athena get-query-execution --region "$REGION" \
+            --query-execution-id "$qid" --query 'QueryExecution.Status.State' --output text)
+        [[ "$state" == "SUCCEEDED" || "$state" == "FAILED" || "$state" == "CANCELLED" ]] && break
+        sleep 0.5
+    done
+    echo "  state: $state"
+    if [[ "$state" == "SUCCEEDED" ]]; then
+        aws athena get-query-results --region "$REGION" --query-execution-id "$qid" --output json \
+            | python3 -c "import sys,json
+d=json.load(sys.stdin); rows=d['ResultSet']['Rows']
+if len(rows)<=1:
+    print('  (0 matching packages)')
+else:
+    print(f'  {len(rows)-1} matching package(s):')
+    for r in rows[1:11]:
+        cells=[c.get('VarCharValue','') for c in r['Data']]
+        print('   -', cells[4] + '/' + cells[0] if len(cells)>=5 else cells)"
+    else
+        echo "  reason: $(aws athena get-query-execution --region "$REGION" \
+            --query-execution-id "$qid" --query 'QueryExecution.Status.StateChangeReason' --output text)"
+    fi
+    echo
+    [[ "$state" == "SUCCEEDED" ]]
+}
+
+# --- Build UNION ALL branches (mirrors _build_iceberg_union_query) ----------
+ESCAPED_VALUE="${VALUE//\'/\'\'}"
+build_query() {
+    local accessor="$1"  # "json" (fixed) or "struct" (buggy)
+    local first="true" sql=""
+    for m in "${MANIFESTS[@]}"; do
+        local bucket="${m%_package_manifest}"
+        local predicate
+        if [[ "$accessor" == "struct" ]]; then
+            predicate="m.metadata.$KEY = '$ESCAPED_VALUE'"
+        else
+            predicate="json_extract_scalar(m.metadata, '\$.$KEY') = '$ESCAPED_VALUE'"
+        fi
+        local branch="SELECT r.pkg_name, r.timestamp, m.message, m.metadata AS user_meta, '$bucket' AS _src_bucket
+FROM \"$DATABASE\".\"${bucket}_package_revision\" r
+JOIN \"$DATABASE\".\"${bucket}_package_manifest\" m ON r.top_hash = m.top_hash
+JOIN \"$DATABASE\".\"${bucket}_package_tag\" t ON r.pkg_name = t.pkg_name AND t.tag_name = 'latest'
+WHERE $predicate"
+        if [[ "$first" == "true" ]]; then sql="$branch"; first="false"
+        else sql="$sql
+UNION ALL
+$branch"; fi
+    done
+    printf '%s' "$sql"
+}
+
+# --- 3. Run the fixed query -------------------------------------------------
+run_query "Fixed query (json_extract_scalar)" "$(build_query json)" && OK="true" || OK="false"
+
+# --- 4. Optionally demonstrate the old failing form -------------------------
+if [[ "$SHOW_BUGGY" == "true" ]]; then
+    run_query "Buggy query (m.metadata.<key> STRUCT access — expected FAIL)" "$(build_query struct)" || true
+fi
+
+if [[ "$OK" == "true" ]]; then
+    echo "✅ Iceberg package search succeeded."
+else
+    echo "❌ Iceberg package search failed — see reason above."
+    exit 1
+fi

--- a/scripts/check-iceberg-search.sh
+++ b/scripts/check-iceberg-search.sh
@@ -17,7 +17,8 @@
 # This script verifies the json_extract_scalar form that avoids that.
 #
 # Config is read from the profile at ~/.config/benchling-webhook/<profile>/config.json
-# (quilt.database is used as the Iceberg Glue database, matching the CDK default).
+# (quilt.icebergDatabase is the Iceberg Glue database, matching QUILT_ICEBERG_DATABASE
+# at runtime; falls back to quilt.database when the Iceberg field is absent).
 #
 # Usage:
 #   scripts/check-iceberg-search.sh --value EXP26000016
@@ -29,7 +30,7 @@
 #   --profile <name>   Profile under ~/.config/benchling-webhook (default: default)
 #   --key <name>       Metadata key to filter on (default: packages.metadataKey from config)
 #   --value <val>      Metadata value to match (required)
-#   --database <name>  Override Iceberg Glue database (default: quilt.database from config)
+#   --database <name>  Override Iceberg Glue database (default: quilt.icebergDatabase, then quilt.database)
 #   --region <name>    Override AWS region (default: quilt.region from config)
 #   --workgroup <name> Override Athena workgroup (default: quilt.athenaUserWorkgroup from config)
 #   --show-buggy       Also run the old STRUCT-access form to demonstrate the failure
@@ -71,6 +72,9 @@ for k in p:
     v = v.get(k, '') if isinstance(v, dict) else ''
 print(v if v is not None else '')"; }
 
+# Prefer the dedicated Iceberg Glue database (matches QUILT_ICEBERG_DATABASE at
+# runtime); fall back to quilt.database only when it is absent.
+DATABASE="${DATABASE:-$(cfg quilt.icebergDatabase)}"
 DATABASE="${DATABASE:-$(cfg quilt.database)}"
 REGION="${REGION:-$(cfg quilt.region)}"
 WORKGROUP="${WORKGROUP:-$(cfg quilt.athenaUserWorkgroup)}"

--- a/spec/a10-bucketless/01-bucketless-req.md
+++ b/spec/a10-bucketless/01-bucketless-req.md
@@ -1,0 +1,188 @@
+# Requirements: Optional Bucket Parameter and Bucketless Package Discovery
+
+**Branch**: a10-bucketless
+**Date**: 2026-07-03
+**Scope**: User requirements only. This document intentionally does not prescribe code structure, implementation mechanisms, or internal algorithms.
+
+## Problem Statement
+
+The Benchling webhook currently assumes that a specific Quilt bucket is configured for package creation and package lookup. This makes deployments less flexible for users who do not want the webhook to target one bucket as the default destination.
+
+Users need the CloudFormation bucket parameter to be optional. When a bucket is not configured, the webhook must operate in a bucketless mode with two externally visible behaviors:
+
+1. The webhook must not automatically create a package for every Benchling notebook entry.
+2. The webhook must search across all accessible buckets when looking for linked packages.
+
+## Definitions
+
+### Bucket Parameter
+
+The CloudFormation parameter that identifies the default Quilt bucket for webhook package operations.
+
+### Bucket-Configured Mode
+
+The deployment mode where the bucket parameter is present and has a valid value.
+
+### Bucketless Mode
+
+The deployment mode where the bucket parameter is omitted, left unset, or otherwise not provided by the deploying user.
+
+### Linked Package
+
+A Quilt package that is already associated with a Benchling notebook entry through user-visible linking metadata, references, or other established linkage recognized by the product.
+
+### Automatic Package Creation
+
+Webhook behavior that creates a new Quilt package as a default side effect of receiving or processing a Benchling notebook entry event.
+
+## User Requirements
+
+### UR-1: The Bucket Parameter Is Optional
+
+**As a** user deploying the Benchling webhook
+**I want** the bucket CloudFormation parameter to be optional
+**So that** I can deploy the webhook without choosing one default Quilt bucket.
+
+**Acceptance Criteria**:
+
+1. A deployment can be configured without providing the bucket parameter.
+2. A deployment without the bucket parameter is considered valid user configuration.
+3. Users are not required to invent a placeholder bucket to complete deployment.
+4. User-facing deployment guidance clearly distinguishes bucket-configured mode from bucketless mode.
+5. Error messages must not describe the missing bucket parameter as a deployment failure when bucketless mode is intended.
+
+### UR-2: Existing Bucket-Configured Behavior Remains Available
+
+**As a** user who already configures a bucket
+**I want** the existing bucket-targeted workflow to remain available
+**So that** current deployments and operational expectations are preserved.
+
+**Acceptance Criteria**:
+
+1. When the bucket parameter is provided, the webhook continues to treat that bucket as the configured bucket.
+2. Users with existing bucket-configured deployments do not need to change their configuration to keep the same workflow.
+3. Documentation describes bucket-configured mode as an available mode, not as a deprecated or invalid configuration.
+4. Bucketless mode does not change the meaning of a provided bucket parameter.
+
+### UR-3: Bucketless Mode Does Not Auto-Create Packages for Every Notebook Entry
+
+**As a** Benchling user whose organization has many notebook entries
+**I want** bucketless mode to avoid automatically creating a Quilt package for every notebook entry
+**So that** the webhook does not produce unwanted packages across my Quilt environment.
+
+**Acceptance Criteria**:
+
+1. When the bucket parameter is not provided, processing a Benchling notebook entry must not create a new default package solely because the notebook entry exists or was changed.
+2. Bucketless mode must not require users to disable the webhook to prevent broad automatic package creation.
+3. Bucketless mode must avoid surprising package proliferation for notebook entries that have no linked package.
+4. User-facing behavior must make it clear that absence of a configured bucket means absence of default package creation.
+5. The webhook may still process notebook entry events for other supported purposes, provided that processing does not create a default package for each entry.
+
+### UR-4: Bucketless Mode Searches All Accessible Buckets for Linked Packages
+
+**As a** user who links Benchling notebook entries to existing Quilt packages
+**I want** bucketless mode to search all accessible Quilt buckets for linked packages
+**So that** linked packages can be found without requiring a single configured bucket.
+
+**Acceptance Criteria**:
+
+1. When the bucket parameter is not provided, linked package lookup must not be limited to one configured bucket.
+2. Bucketless mode must search every bucket that the deployed webhook is authorized to inspect.
+3. If a linked package exists in any accessible bucket, bucketless mode must be capable of finding it.
+4. Users must not need to duplicate linked packages into a single default bucket for the webhook to find them.
+5. If no linked package is found in any accessible bucket, the user-visible result must clearly indicate that no linked package was found.
+6. If the webhook lacks access to one or more expected buckets, the user-visible result or operational documentation must make the access boundary understandable.
+
+### UR-5: Bucketless Mode Updates Linked Packages Without Creating Unlinked Packages
+
+**As a** user maintaining Benchling-linked Quilt packages
+**I want** bucketless mode to operate on packages that are already linked
+**So that** existing package relationships continue to work without generating unrelated packages.
+
+**Acceptance Criteria**:
+
+1. When a notebook entry has a linked package in an accessible bucket, bucketless mode may perform the supported package-related behavior for that linked package.
+2. When a notebook entry has no linked package in any accessible bucket, bucketless mode must not create a new package as a fallback default behavior.
+3. Bucketless mode must preserve the distinction between "linked package found" and "no linked package found."
+4. Users must be able to reason from observable results whether the webhook acted on an existing linked package or skipped package work because no link existed.
+
+### UR-6: Search Scope Is User-Comprehensible
+
+**As an** administrator responsible for Quilt bucket access
+**I want** the bucketless search scope to be clearly described
+**So that** I understand which buckets can participate in linked package discovery.
+
+**Acceptance Criteria**:
+
+1. User documentation explains that bucketless mode searches accessible buckets, not every bucket in every account unconditionally.
+2. User documentation explains that access permissions define the practical search scope.
+3. If multiple deployment contexts are supported, the documentation identifies whose permissions determine bucket accessibility.
+4. The product must not imply that inaccessible buckets will be searched.
+
+### UR-7: Ambiguous or Duplicate Linked Packages Are Handled Predictably
+
+**As a** user with packages across multiple buckets
+**I want** bucketless mode to behave predictably if more than one linked package matches a notebook entry
+**So that** package actions do not target the wrong package silently.
+
+**Acceptance Criteria**:
+
+1. If exactly one linked package is found across accessible buckets, that package is the unambiguous match.
+2. If multiple linked packages are found for the same notebook entry, the user-visible behavior must avoid silent arbitrary selection.
+3. Duplicate-match behavior must be documented.
+4. The result for duplicate matches must be understandable to an administrator troubleshooting the notebook entry.
+
+### UR-8: Bucketless Mode Has Clear Operational Feedback
+
+**As an** operator of the webhook
+**I want** clear feedback about bucketless behavior
+**So that** I can distinguish expected no-op behavior from failures.
+
+**Acceptance Criteria**:
+
+1. When bucketless mode skips package creation because no linked package exists, that outcome must be distinguishable from an error.
+2. When bucketless mode finds and acts on a linked package, that outcome must be distinguishable from a skipped event.
+3. When bucketless mode cannot complete linked package lookup because of permissions or service availability, that outcome must be distinguishable from "no linked package exists."
+4. Operational feedback must not expose sensitive package, bucket, or Benchling data beyond what an authorized operator should see.
+
+### UR-9: Bucketless Mode Is Safe by Default
+
+**As an** organization adopting the webhook
+**I want** omission of the bucket parameter to result in conservative behavior
+**So that** the webhook does not create storage artifacts or packages unexpectedly.
+
+**Acceptance Criteria**:
+
+1. Missing bucket configuration must not trigger broad package creation.
+2. Missing bucket configuration must not choose an arbitrary bucket as a default target.
+3. Missing bucket configuration must not infer a package destination from unrelated deployment metadata.
+4. Bucketless mode may discover existing linked packages, but it must not invent new package destinations for unlinked notebook entries.
+
+## Non-Requirements
+
+The following are explicitly outside this requirements document:
+
+1. Specific code changes, classes, functions, modules, or file paths.
+2. Specific CloudFormation template syntax.
+3. Specific API calls used to list buckets, inspect packages, or resolve links.
+4. Specific data structures used to represent package links.
+5. Performance optimizations or caching strategies.
+6. Migration scripts.
+7. Changes to package-linking semantics beyond the user-visible bucketless behavior described above.
+
+## Success Criteria
+
+1. Users can deploy without a bucket parameter.
+2. Users who provide a bucket retain the bucket-configured workflow.
+3. Bucketless deployments do not create a package for every notebook entry.
+4. Bucketless deployments find linked packages across all accessible buckets.
+5. Bucketless deployments clearly report the difference between linked-package success, no linked package found, duplicate linked packages, and lookup failure.
+6. Documentation makes the two modes and their consequences clear to deployers and operators.
+
+## Open Questions
+
+1. What exact user-visible signal defines that a Quilt package is linked to a Benchling notebook entry?
+2. If multiple linked packages are found across accessible buckets, should the preferred user outcome be an error, a warning with no action, or a deterministic documented selection rule?
+3. Should bucketless mode expose a way for users to preview or audit which buckets are accessible before processing events?
+4. Are there user-facing limits needed for very large organizations with many accessible buckets?
+5. Should bucketless mode be the recommended default for new deployments, or should documentation present both modes neutrally?

--- a/spec/a10-bucketless/02-bucketless-audit.md
+++ b/spec/a10-bucketless/02-bucketless-audit.md
@@ -1,0 +1,549 @@
+# Audit: Code Paths Affected by Bucketless Mode
+
+**Branch**: a10-bucketless
+**Date**: 2026-07-03
+**Scope**: Identify which code paths must be revisited for bucketless mode. This document intentionally does not prescribe how to change them.
+
+## Requirements Trace
+
+This audit maps code paths to the user requirements in [01-bucketless-req.md](./01-bucketless-req.md):
+
+1. The bucket CloudFormation parameter is optional.
+2. When the bucket is absent, entry events must not auto-create packages for every notebook entry.
+3. When the bucket is absent, linked-package lookup must search all accessible buckets.
+4. Existing bucket-configured behavior must remain available.
+
+## Summary
+
+The current codebase treats the package bucket as required in three layers:
+
+1. **Setup and profile configuration** require `packages.bucket`.
+2. **Deployment and stack synthesis** pass a single `PackageBucket` value into the service and IAM policy model.
+3. **Runtime Python code** stores a single bucket in `config.s3_bucket_name` and uses it for package writes, package-creation messages, linked-package search, package browsing, package-event filtering, and canvas links.
+
+Bucketless mode therefore touches both deployment-time configuration and runtime behavior. The highest-risk behavior path is the entry-event path: supported Benchling entry events are always enqueued for packaging, and the packaging consumer always runs `EntryPackager.execute_workflow`, which exports entry data, writes to S3, and sends a package-creation message.
+
+## Must Change: Configuration and Deployment Inputs
+
+### `lib/types/config.ts`
+
+Current path:
+
+- `PackageConfig.bucket` is typed as required.
+- The profile schema requires `packages.bucket`.
+- The schema enforces `bucket` `minLength: 3`.
+
+Evidence:
+
+- `PackageConfig.bucket`: `lib/types/config.ts:311`
+- required schema entry: `lib/types/config.ts:761`
+- bucket schema constraint: `lib/types/config.ts:765`
+
+Why it must change:
+
+- User requirement UR-1 says the bucket parameter is optional.
+- Any profile-level validation that rejects missing `packages.bucket` blocks bucketless mode before deployment.
+
+### `lib/wizard/phase3-parameter-collection.ts`
+
+Current path:
+
+- Package configuration collection declares a bucket variable.
+- Non-interactive setup fails when no bucket is supplied.
+- User-facing output assumes a bucket is present.
+
+Evidence:
+
+- package configuration prompt block: `lib/wizard/phase3-parameter-collection.ts:310`
+- CLI bucket assignment: `lib/wizard/phase3-parameter-collection.ts:320`
+- non-interactive bucket fallback: `lib/wizard/phase3-parameter-collection.ts:331`
+- missing bucket error: `lib/wizard/phase3-parameter-collection.ts:336`
+
+Why it must change:
+
+- Bucketless mode must be a valid setup outcome.
+- Setup must not require users to invent a placeholder bucket.
+
+### `lib/wizard/profile-config-builder.ts`
+
+Current path:
+
+- New profiles always write `packages.bucket`.
+- Existing-config setup throws when neither existing config nor secret details include a package bucket.
+- Built profile config asserts a bucket value.
+
+Evidence:
+
+- new profile package bucket assignment: `lib/wizard/profile-config-builder.ts:72`
+- existing profile bucket source: `lib/wizard/profile-config-builder.ts:113`
+- missing bucket error: `lib/wizard/profile-config-builder.ts:123`
+- package config bucket assertion: `lib/wizard/profile-config-builder.ts:145`
+
+Why it must change:
+
+- Existing configurations and secrets without a package bucket must be representable.
+- Profile creation must be able to describe bucketless mode.
+
+### `lib/wizard/phase4-validation.ts`
+
+Current path:
+
+- Setup validation always validates S3 bucket access.
+- Failure output always includes an S3 bucket line.
+
+Evidence:
+
+- S3 bucket validation call: `lib/wizard/phase4-validation.ts:286`
+- validation failure output: `lib/wizard/phase4-validation.ts:301`
+
+Why it must change:
+
+- Missing bucket cannot be treated as failed S3 validation when bucketless mode is intended.
+- User-facing validation output must distinguish bucketless mode from invalid bucket configuration.
+
+### `lib/configuration-validator.ts`
+
+Current path:
+
+- `quiltUserBucket` is listed as a required field for older/general configuration validation.
+
+Evidence:
+
+- required field list: `lib/configuration-validator.ts:45`
+- S3 validation gated on `quiltUserBucket`: `lib/configuration-validator.ts:116`
+
+Why it likely must change:
+
+- Any active command or legacy path using this validator would reject bucketless configuration.
+- The S3 validation gate is already conditional, but the required-field check is not.
+
+### `lib/utils/config.ts`
+
+Current path:
+
+- Legacy/general config metadata describes the S3 bucket as explicitly required and not inferable.
+- Validation treats present-but-invalid buckets as warnings, but user guidance still says the bucket must be provided.
+
+Evidence:
+
+- required messaging for `quiltUserBucket`: `lib/utils/config.ts:205`
+- bucket format validation: `lib/utils/config.ts:250`
+
+Why it likely must change:
+
+- User-facing config guidance must stop representing the bucket as universally required.
+
+## Must Change: Secret Shape and Runtime Config Loading
+
+### `bin/commands/sync-secrets.ts`
+
+Current path:
+
+- The secret JSON always includes `user_bucket` from `config.packages.bucket`.
+
+Evidence:
+
+- secret construction: `bin/commands/sync-secrets.ts:292`
+- `user_bucket` assignment: `bin/commands/sync-secrets.ts:299`
+
+Why it must change:
+
+- Bucketless profiles must be syncable to Secrets Manager.
+- Runtime cannot depend on a required `user_bucket` field when the deployment is bucketless.
+
+### `bin/commands/create-secret.ts`
+
+Current path:
+
+- The secret interface requires `user_bucket`.
+- The generated secret data always includes `user_bucket` from `BENCHLING_USER_BUCKET`.
+
+Evidence:
+
+- `BenchlingSecretData.user_bucket`: `bin/commands/create-secret.ts:39`
+- generated `user_bucket`: `bin/commands/create-secret.ts:117`
+
+Why it likely must change:
+
+- Manual secret creation must support bucketless mode if this command remains a supported user path.
+
+### `docker/src/secrets_manager.py`
+
+Current path:
+
+- `BenchlingSecretData.user_bucket` is required.
+- Secret validation requires `user_bucket`.
+- Secret validation rejects empty `user_bucket`.
+- Parsed secrets always populate `user_bucket`.
+
+Evidence:
+
+- dataclass field: `docker/src/secrets_manager.py:70`
+- required field list: `docker/src/secrets_manager.py:185`
+- example secret includes `user_bucket`: `docker/src/secrets_manager.py:199`
+- non-empty string validation includes `user_bucket`: `docker/src/secrets_manager.py:239`
+- parsed value assignment: `docker/src/secrets_manager.py:260`
+
+Why it must change:
+
+- Runtime startup and secret refresh must not fail just because bucketless mode has no package bucket.
+
+### `docker/src/config_schema.py`
+
+Current path:
+
+- `SecretConfig.user_bucket` is required.
+
+Evidence:
+
+- Pydantic field: `docker/src/config_schema.py:175`
+
+Why it likely must change:
+
+- Any schema validation path using `SecretConfig` will reject bucketless secrets.
+
+### `docker/src/config.py`
+
+Current path:
+
+- Applying secrets sets `self.s3_bucket_name` directly from `secret_data.user_bucket`.
+
+Evidence:
+
+- secret application block: `docker/src/config.py:292`
+- bucket assignment: `docker/src/config.py:304`
+
+Why it must change:
+
+- Runtime code needs a valid representation for "no configured bucket."
+- Every downstream consumer of `config.s3_bucket_name` must be audited for bucketless behavior.
+
+## Must Change: CloudFormation and ECS Service Wiring
+
+### `lib/benchling-webhook-stack.ts`
+
+Current path:
+
+- The stack defines a `PackageBucket` CloudFormation parameter.
+- The stack passes `packageBucketValue` to `FargateService`.
+
+Evidence:
+
+- `PackageBucket` parameter: `lib/benchling-webhook-stack.ts:127`
+- parameter value extraction: `lib/benchling-webhook-stack.ts:147`
+- Fargate prop assignment: `lib/benchling-webhook-stack.ts:329`
+
+Why it must change:
+
+- The CloudFormation parameter must support absence as a valid user choice.
+- The stack must not make downstream service behavior depend on a required non-empty bucket.
+
+### `lib/fargate-service.ts`
+
+Current path:
+
+- `FargateServiceProps.packageBucket` is required.
+- The task role always constructs an S3 ARN from `props.packageBucket`.
+- The task role always grants bucket-specific S3 permissions based on that ARN.
+
+Evidence:
+
+- required prop: `lib/fargate-service.ts:46`
+- bucket ARN construction: `lib/fargate-service.ts:150`
+- bucket-specific policy resources: `lib/fargate-service.ts:171`
+
+Why it must change:
+
+- Bucketless mode cannot create meaningful bucket-specific IAM resources from an absent bucket.
+- The permission model must align with the user requirement that bucketless linked-package search covers all accessible buckets.
+
+### `bin/commands/deploy.ts`
+
+Current path:
+
+- Deployment plan summarizes events with `config.packages.bucket`.
+- CloudFormation deployment parameters always include `PackageBucket=${config.packages.bucket}`.
+
+Evidence:
+
+- event summary: `bin/commands/deploy.ts:637`
+- stack parameter list: `bin/commands/deploy.ts:779`
+- `PackageBucket` parameter: `bin/commands/deploy.ts:794`
+
+Why it must change:
+
+- Deploy must allow the bucket parameter to be omitted or empty intentionally.
+- User-facing deploy output must identify bucketless mode rather than rendering a misleading bucket-based event summary.
+
+## Must Change: Entry-Event Auto-Creation Path
+
+### `docker/src/app.py`
+
+Current path:
+
+- Supported Benchling entry events are always enqueued as packaging requests.
+- Supported events include `v2.entry.created`, `v2.entry.updated.fields`, and `v2.entry.updated.reviewRecord`.
+
+Evidence:
+
+- supported entry event set: `docker/src/app.py:749`
+- packaging request enqueue: `docker/src/app.py:761`
+- success log says packaging request was enqueued: `docker/src/app.py:763`
+
+Why it must change:
+
+- UR-3 says bucketless mode must not automatically create a package for every notebook entry.
+- This is the first runtime gate where entry events become package work.
+
+### `docker/src/packaging_publisher.py`
+
+Current path:
+
+- The publisher is specifically the path from webhook handler to FIFO packaging work.
+
+Evidence:
+
+- module purpose: `docker/src/packaging_publisher.py:1`
+- publish function: `docker/src/packaging_publisher.py:41`
+
+Why it may need change:
+
+- If entry events remain accepted but should not become package-creation work in bucketless mode, this path is part of the affected behavior boundary.
+
+### `docker/src/packaging_consumer.py`
+
+Current path:
+
+- Every packaging request consumed from the FIFO queue dispatches to `EntryPackager.execute_workflow`.
+
+Evidence:
+
+- payload parsing and workflow dispatch: `docker/src/packaging_consumer.py:81`
+- `execute_workflow` call: `docker/src/packaging_consumer.py:84`
+
+Why it may need change:
+
+- This is the second runtime gate before automatic package creation.
+- If bucketless behavior is not fully gated before enqueue, this path must not run package-creation workflow for unlinked notebook entries.
+
+### `docker/src/entry_packager.py`
+
+Current path:
+
+- `execute_workflow` exports the Benchling entry, writes files to the configured S3 bucket, sends a Quilt package-creation message, and returns a package success result.
+- `_process_export` writes exported files and metadata to `self.config.s3_bucket_name`.
+- `_send_to_sqs` sends a package-creation request with `source_prefix`, `registry`, and `package_name`.
+
+Evidence:
+
+- package name derivation and export processing: `docker/src/entry_packager.py:477`
+- S3 object writes: `docker/src/entry_packager.py:523`
+- metadata S3 writes: `docker/src/entry_packager.py:549`
+- existing `entry.json` read from configured bucket: `docker/src/entry_packager.py:785`
+- package-creation message body: `docker/src/entry_packager.py:829`
+- workflow sends package-creation SQS message: `docker/src/entry_packager.py:926`
+- success result reports package creation workflow success: `docker/src/entry_packager.py:954`
+
+Why it must change:
+
+- This is the core auto-create-package path.
+- It cannot run as-is when no bucket is configured.
+- It assumes one target registry bucket for both staging exported files and creating package revisions.
+
+## Must Change: Linked-Package Lookup Scope
+
+### `docker/src/canvas.py`
+
+Current path:
+
+- `CanvasManager` constructs `PackageQuery` with exactly `config.s3_bucket_name`.
+- Canvas content asks that single query object for linked packages.
+- The footer renders one configured bucket.
+- Sync URIs are built from `config.s3_bucket_name`.
+
+Evidence:
+
+- `PackageQuery` construction: `docker/src/canvas.py:70`
+- `PackageFileFetcher` construction: `docker/src/canvas.py:76`
+- sync URI bucket: `docker/src/canvas.py:127`
+- linked-package query call: `docker/src/canvas.py:205`
+- footer bucket: `docker/src/canvas.py:271`
+
+Why it must change:
+
+- UR-4 says bucketless linked-package lookup must search all accessible buckets.
+- The current canvas path limits linked-package search to one configured bucket.
+- Bucketless UI cannot truthfully render a single configured bucket in places where no configured bucket exists.
+
+### `docker/src/package_query.py`
+
+Current path:
+
+- `PackageQuery` represents one bucket.
+- Its Athena query targets one bucket-specific packages view.
+- Returned `Package` objects carry that single bucket.
+
+Evidence:
+
+- class docstring describes one bucket-specific view: `docker/src/package_query.py:35`
+- constructor bucket argument: `docker/src/package_query.py:46`
+- view name from one bucket: `docker/src/package_query.py:213`
+- result bucket assignment: `docker/src/package_query.py:250`
+- `Package` creation with one bucket: `docker/src/package_query.py:260`
+
+Why it must change:
+
+- This is the linked-package lookup implementation path that currently prevents all-accessible-bucket search.
+- Bucketless mode requires lookup behavior that is not limited to one bucket-specific view.
+
+### `docker/src/packages.py`
+
+Current path:
+
+- `Package` requires a bucket and uses it in catalog URLs.
+
+Evidence:
+
+- constructor bucket argument: `docker/src/packages.py:39`
+- catalog URL includes bucket: `docker/src/packages.py:51`
+
+Why it likely remains involved:
+
+- All-accessible-bucket search still needs to preserve the bucket for each found linked package.
+- Duplicate linked-package handling depends on identifying matches across package name and bucket.
+
+## Must Change or Reassess: Package Browsing and Package Events
+
+### `docker/src/package_files.py`
+
+Current path:
+
+- `PackageFileFetcher` represents one bucket-backed registry.
+- It creates a registry from `s3://{self.bucket}`.
+
+Evidence:
+
+- constructor bucket argument: `docker/src/package_files.py:101`
+- registry construction: `docker/src/package_files.py:126`
+
+Why it may need change:
+
+- Browsing linked packages found in different buckets must use the found package's bucket, not an absent or unrelated configured bucket.
+
+### `docker/src/canvas_blocks.py`
+
+Current path:
+
+- Linked-package browse button IDs encode package name but not bucket.
+
+Evidence:
+
+- linked browse button creation: `docker/src/canvas_blocks.py:222`
+- button ID creation: `docker/src/canvas_blocks.py:243`
+
+Why it may need change:
+
+- In bucketless mode, the same package name may exist in more than one accessible bucket.
+- Browse interactions need enough user-visible context to avoid silently targeting the wrong linked package.
+
+### `docker/src/package_event.py`
+
+Current path:
+
+- Package revision refresh fetches package metadata using `config.s3_bucket_name`.
+
+Evidence:
+
+- `PackageFileFetcher` construction: `docker/src/package_event.py:90`
+
+Why it may need change:
+
+- Package revision events include a registry bucket.
+- Bucketless mode cannot assume the configured bucket when refreshing canvases for linked packages across accessible buckets.
+
+### `docker/src/sqs_consumer.py`
+
+Current path:
+
+- Package event consumer filters out events whose bucket does not equal `config.s3_bucket_name`.
+
+Evidence:
+
+- bucket filter: `docker/src/sqs_consumer.py:199`
+- unexpected-bucket log fields: `docker/src/sqs_consumer.py:203`
+
+Why it must change or be explicitly scoped:
+
+- UR-4 requires searching all accessible buckets for linked packages.
+- If bucketless mode also expects package-event refreshes for linked packages outside a configured bucket, this filter prevents that behavior.
+
+## Test Paths That Need Coverage Updates
+
+### TypeScript tests
+
+Likely affected:
+
+- `test/config-transform.test.ts`
+- `test/configuration-validator.test.ts`
+- `test/s3-bucket-validator.test.ts`
+- `test/sync-secrets.test.ts`
+- `test/rest-api-gateway.test.ts`
+- `test/benchling-webhook-stack.test.ts`
+- `test/multi-environment-fargate-service.test.ts`
+- `test/unit/xdg-config.test.ts`
+- `test/unit/xdg-config-filesystem.test.ts`
+- `test/bin/commands/setup-wizard.test.ts`
+- `test/bin/install.test.ts`
+- `test/bin/commands/status.test.ts`
+- `test/integration/legacy-detection.test.ts`
+- `test/integration/xdg-launch-pure-functions.test.ts`
+
+Why:
+
+- These tests construct profile configs with required `packages.bucket`, assert bucket validation behavior, assert stack parameters, or assert ECS permissions/env behavior.
+
+### Python tests
+
+Likely affected:
+
+- `docker/tests/test_config_validation.py`
+- `docker/tests/test_secrets_resolver.py`
+- `docker/tests/test_app.py`
+- `docker/tests/test_flexible_routes.py`
+- `docker/tests/test_entry_packager.py`
+- `docker/tests/test_packaging_consumer.py`
+- `docker/tests/test_canvas.py`
+- `docker/tests/test_canvas_browser.py`
+- `docker/tests/test_browse_linked_packages.py`
+- `docker/tests/test_package_files.py`
+- `docker/tests/test_package_event.py`
+- `docker/tests/test_sqs_consumer.py`
+
+Why:
+
+- These tests set `config.s3_bucket_name`, expect `user_bucket` in secrets, expect entry events to enqueue packaging, expect single-bucket canvas/package browsing, or expect package-event bucket filtering.
+
+## Documentation and User-Facing Text Paths
+
+Likely affected:
+
+- `README.md`
+- `docker/src/README.md`
+- `bin/commands/validate.ts`
+- `bin/commands/deploy.ts`
+- setup wizard output in `lib/wizard/*`
+- secret-format examples in `docker/src/secrets_manager.py`
+- config guidance in `lib/utils/config.ts`
+
+Why:
+
+- User-facing documentation and CLI output currently describe a bucket-centered deployment and package workflow.
+- Bucketless mode requires clear wording that missing bucket is valid and suppresses default package creation.
+
+## Open Audit Questions
+
+1. Should bucketless mode suppress packaging at the webhook handler boundary, the packaging consumer boundary, or both?
+2. Should canvas initialization in bucketless mode still show a primary package section when no linked package exists?
+3. What source defines the complete set of accessible buckets for linked-package lookup?
+4. Should package revision events be accepted from all accessible buckets in bucketless mode, or only from buckets with known linked packages?
+5. How should duplicate linked-package matches across buckets be surfaced in canvas interactions and logs?

--- a/spec/a10-bucketless/03-bucketless-checklist.md
+++ b/spec/a10-bucketless/03-bucketless-checklist.md
@@ -1,0 +1,339 @@
+# Checklist: Bucketless Mode Implementation, Tests, and Test Stack Deployment
+
+**Branch**: a10-bucketless
+**Date**: 2026-07-03
+**References**: `01-bucketless-req.md`, `02-bucketless-audit.md`
+**Scope**: Enumerated tasks only. No code or implementation snippets.
+
+## Checklist Instructions
+
+- Use `[x]` to mark completed tasks.
+- Use `[ ]` for pending tasks.
+- Keep commits focused by episode.
+- Run `npm test` before any commit intended for review.
+- Fix IDE diagnostics after edits.
+- Use project npm scripts rather than raw tool commands when an npm script exists.
+- Use `--` when passing args to npm scripts.
+
+## Pre-Implementation Setup
+
+### Repository State
+
+- [ ] Confirm branch is `a10-bucketless`.
+- [ ] Confirm branch is based on current `main`.
+- [ ] Confirm working tree contains only intended spec changes before implementation begins.
+- [ ] Read `spec/a10-bucketless/01-bucketless-req.md`.
+- [ ] Read `spec/a10-bucketless/02-bucketless-audit.md`.
+- [ ] Review current npm scripts with `npm run`.
+- [ ] Install dependencies if needed with `npm install`.
+
+### Baseline Validation
+
+- [ ] Run `npm run build:typecheck`.
+- [ ] Run `npm run test:unit`.
+- [ ] Run `npm run test:python`.
+- [ ] Run `npm test` if the targeted baseline commands pass.
+- [ ] Record any pre-existing failures before making code changes.
+- [ ] Confirm IDE diagnostics are clear or record pre-existing diagnostics.
+
+## Episode 1: Make Bucket Optional in User Configuration
+
+### Implementation Tasks
+
+- [ ] Update user-facing config types so package bucket can be absent.
+- [ ] Update profile schema validation so `packages.bucket` is not globally required.
+- [ ] Preserve validation for malformed bucket values when a bucket is provided.
+- [ ] Update setup wizard parameter collection so non-interactive setup can intentionally produce bucketless config.
+- [ ] Update profile config builders so new and existing profile flows can represent bucketless mode.
+- [ ] Update setup validation so S3 bucket access validation only applies when a bucket is configured.
+- [ ] Update legacy/general configuration validators that still require `quiltUserBucket`.
+- [ ] Update user-facing setup messages to distinguish bucket-configured mode from bucketless mode.
+
+### Unit Tests
+
+- [ ] Add TypeScript tests for valid bucketless profile config.
+- [ ] Add TypeScript tests that a provided valid bucket still passes validation.
+- [ ] Add TypeScript tests that a provided invalid bucket still fails or warns according to existing conventions.
+- [ ] Add setup wizard tests for non-interactive bucketless setup.
+- [ ] Add setup wizard tests proving existing bucket-configured setup remains unchanged.
+- [ ] Update existing config fixture tests that assume `packages.bucket` is mandatory.
+
+### Quality Gates
+
+- [ ] Run `npm run build:typecheck`.
+- [ ] Run affected TypeScript tests.
+- [ ] Confirm IDE diagnostics are clear.
+
+## Episode 2: Make Bucket Optional in Secrets and Runtime Config
+
+### Implementation Tasks
+
+- [ ] Update secret creation and sync flows so `user_bucket` can be absent for bucketless profiles.
+- [ ] Update secret examples and validation messages to distinguish required Benchling credentials from optional package bucket.
+- [ ] Update Python secret data models so bucketless secrets are valid.
+- [ ] Update Python secret parsing so missing bucket does not fail startup.
+- [ ] Update runtime config application so `config.s3_bucket_name` has a clear bucketless representation.
+- [ ] Audit every direct read of `config.s3_bucket_name` and classify it as bucket-required, bucketless-aware, or unchanged.
+
+### Unit Tests
+
+- [ ] Add TypeScript tests for syncing a bucketless secret.
+- [ ] Add TypeScript tests for syncing a bucket-configured secret.
+- [ ] Add Python tests for parsing bucketless secrets.
+- [ ] Add Python tests for parsing existing bucket-configured secrets.
+- [ ] Add Python tests proving missing Benchling credentials still fail validation.
+- [ ] Update secret resolver tests that assume `user_bucket` is always present.
+
+### Quality Gates
+
+- [ ] Run `npm run build:typecheck`.
+- [ ] Run affected TypeScript secret/config tests.
+- [ ] Run affected Python secret/config tests.
+- [ ] Confirm IDE diagnostics are clear.
+
+## Episode 3: Make CloudFormation and ECS Wiring Bucketless-Aware
+
+### Implementation Tasks
+
+- [ ] Update `PackageBucket` CloudFormation parameter behavior so an absent bucket is valid.
+- [ ] Update CDK stack synthesis so bucketless mode does not create invalid bucket-specific IAM resources.
+- [ ] Preserve bucket-specific permissions and environment behavior when a bucket is configured.
+- [ ] Update ECS service props and task role behavior for both modes.
+- [ ] Update deployment command parameter construction for bucketless profiles.
+- [ ] Update deployment plan output so bucketless mode is explicit and not shown as a blank bucket.
+- [ ] Confirm centralized ECR image configuration remains unchanged.
+
+### Unit Tests
+
+- [ ] Add CDK template tests for bucketless stack synthesis.
+- [ ] Add CDK template tests for bucket-configured stack synthesis.
+- [ ] Add ECS task role tests for bucketless permissions.
+- [ ] Add ECS task role tests proving existing bucket-configured permissions remain available.
+- [ ] Add deploy command tests for bucketless parameter handling.
+- [ ] Update snapshot or assertion tests that assume `PackageBucket` is always populated.
+
+### Quality Gates
+
+- [ ] Run `npm run build:typecheck`.
+- [ ] Run CDK and deployment-related TypeScript tests.
+- [ ] Confirm synthesized templates do not contain invalid empty-bucket ARNs.
+- [ ] Confirm IDE diagnostics are clear.
+
+## Episode 4: Stop Bucketless Entry Events from Auto-Creating Packages
+
+### Implementation Tasks
+
+- [ ] Identify the authoritative runtime mode check for bucketless behavior.
+- [ ] Update the entry-event processing path so bucketless mode does not enqueue automatic package creation for every notebook entry.
+- [ ] Preserve canvas event behavior needed for user-visible canvas updates.
+- [ ] Preserve bucket-configured entry-event behavior.
+- [ ] Ensure skipped bucketless entry events produce clear operational feedback.
+- [ ] Ensure skipped bucketless entry events are not reported as failures.
+- [ ] Ensure unsupported event behavior remains unchanged.
+
+### Unit Tests
+
+- [ ] Add Python tests for `v2.entry.created` in bucketless mode.
+- [ ] Add Python tests for `v2.entry.updated.fields` in bucketless mode.
+- [ ] Add Python tests for `v2.entry.updated.reviewRecord` in bucketless mode.
+- [ ] Add Python tests proving bucketless entry events do not enqueue packaging requests.
+- [ ] Add Python tests proving bucket-configured entry events still enqueue packaging requests.
+- [ ] Add Python tests for response body and logs or observable status for skipped bucketless package creation.
+- [ ] Update packaging publisher and consumer tests if their assumptions about accepted work change.
+
+### Quality Gates
+
+- [ ] Run affected Python app and flexible-route tests.
+- [ ] Run affected packaging publisher and consumer tests.
+- [ ] Run `npm run test:python`.
+- [ ] Confirm IDE diagnostics are clear.
+
+## Episode 5: Make Linked-Package Lookup Search Across Accessible Buckets
+
+### Implementation Tasks
+
+- [ ] Identify the product-approved source of accessible buckets for runtime lookup.
+- [ ] Update linked-package lookup so bucketless mode searches all accessible buckets.
+- [ ] Preserve single-bucket linked-package lookup when a bucket is configured.
+- [ ] Preserve enough bucket identity on each linked package result for URLs, browsing, and duplicate handling.
+- [ ] Define observable behavior for no linked package found.
+- [ ] Define observable behavior for lookup failure.
+- [ ] Define observable behavior for duplicate linked packages across buckets.
+- [ ] Ensure lookup feedback is understandable in Canvas and logs.
+
+### Unit Tests
+
+- [ ] Add Python tests for bucketless lookup across multiple accessible buckets.
+- [ ] Add Python tests for no linked packages found in bucketless mode.
+- [ ] Add Python tests for duplicate linked packages across buckets.
+- [ ] Add Python tests for partial or total lookup failure.
+- [ ] Add Python tests proving bucket-configured lookup remains scoped to the configured bucket.
+- [ ] Add tests for package result objects preserving bucket identity.
+- [ ] Update canvas tests that assume linked-package lookup uses only `config.s3_bucket_name`.
+
+### Quality Gates
+
+- [ ] Run affected package query tests.
+- [ ] Run affected canvas tests.
+- [ ] Run `npm run test:python`.
+- [ ] Confirm IDE diagnostics are clear.
+
+## Episode 6: Update Canvas Browsing, Sync Links, and Package Event Refresh
+
+### Implementation Tasks
+
+- [ ] Update primary canvas content for bucketless mode so it does not imply a default package exists when none does.
+- [ ] Update footer and status text so bucketless mode is clear.
+- [ ] Update linked-package browse interactions so the selected linked package's bucket is preserved.
+- [ ] Update file browsing so linked packages in different buckets can be opened correctly.
+- [ ] Update metadata browsing so linked packages in different buckets can be inspected correctly.
+- [ ] Update sync links so they are only shown when the package destination is known.
+- [ ] Reassess package revision event filtering for bucketless mode.
+- [ ] Update package revision canvas refresh to use the event package bucket where appropriate.
+- [ ] Preserve existing behavior for bucket-configured deployments.
+
+### Unit Tests
+
+- [ ] Add canvas rendering tests for bucketless mode with no linked packages.
+- [ ] Add canvas rendering tests for bucketless mode with one linked package.
+- [ ] Add canvas rendering tests for bucketless mode with linked packages in multiple buckets.
+- [ ] Add browse-linked-package tests that include bucket identity.
+- [ ] Add package file fetcher tests for linked packages outside the configured bucket.
+- [ ] Add package event consumer tests for bucketless package events.
+- [ ] Add package event refresh tests using event bucket identity.
+- [ ] Update existing tests that assume browse button package name alone is sufficient.
+
+### Quality Gates
+
+- [ ] Run affected canvas, browse, package files, package event, and SQS consumer tests.
+- [ ] Run `npm run test:python`.
+- [ ] Confirm IDE diagnostics are clear.
+
+## Episode 7: Update CLI, Docs, and User-Facing Guidance
+
+### Implementation Tasks
+
+- [ ] Update README setup instructions for bucket-configured and bucketless modes.
+- [ ] Update secret-format documentation for optional bucket behavior.
+- [ ] Update deployment plan wording for bucketless mode.
+- [ ] Update validation command output for bucketless mode.
+- [ ] Update local testing notes if setup commands differ for bucketless profiles.
+- [ ] Update troubleshooting guidance for no linked package found.
+- [ ] Update troubleshooting guidance for inaccessible buckets.
+- [ ] Update troubleshooting guidance for duplicate linked packages.
+
+### Documentation Checks
+
+- [ ] Confirm docs do not say the bucket is universally required.
+- [ ] Confirm docs state that bucketless mode does not auto-create packages for every notebook entry.
+- [ ] Confirm docs state that bucketless mode searches accessible buckets for linked packages.
+- [ ] Confirm docs explain that permissions define accessible buckets.
+- [ ] Confirm docs preserve instructions for bucket-configured deployments.
+
+### Quality Gates
+
+- [ ] Run documentation-adjacent TypeScript tests if CLI output tests changed.
+- [ ] Confirm IDE diagnostics are clear.
+
+## Episode 8: Full Unit and Local Verification
+
+### TypeScript Verification
+
+- [ ] Run `npm run build:typecheck`.
+- [ ] Run `npm run test:ts`.
+- [ ] Run `npm run test:unit`.
+
+### Python Verification
+
+- [ ] Run `npm run test:python`.
+- [ ] Run targeted Python tests for bucketless runtime behavior.
+
+### Full Project Verification
+
+- [ ] Run `npm test`.
+- [ ] Fix all lint, typecheck, and test failures.
+- [ ] Confirm IDE diagnostics are clear.
+- [ ] Review `git diff` for unrelated changes.
+
+### Local Container Verification
+
+- [ ] Run `npm run test:local`.
+- [ ] Verify bucket-configured local behavior still passes.
+- [ ] Run the available local command or profile path for bucketless behavior.
+- [ ] Verify bucketless local behavior does not auto-create packages for entry events.
+- [ ] Verify bucketless local behavior can render linked-package lookup outcomes.
+
+## Episode 9: Deploy a Testable Bucketless Stack
+
+### Pre-Deployment Preparation
+
+- [ ] Confirm the target profile for bucketless testing.
+- [ ] Confirm the target stage is `dev`.
+- [ ] Confirm required Benchling credentials are available in the profile or secret.
+- [ ] Confirm Quilt catalog, database, queue, workgroup, and managed policies are available as needed.
+- [ ] Confirm no bucket is configured for the bucketless test profile.
+- [ ] Confirm expected accessible buckets for linked-package lookup.
+- [ ] Confirm AWS account and region before deploying.
+
+### Deployment
+
+- [ ] Run setup or profile update for the bucketless test profile using project npm scripts.
+- [ ] Run `npm run setup:sync-secrets -- --profile <bucketless-profile>` if secrets need syncing.
+- [ ] Run `npm run deploy:dev -- --profile <bucketless-profile> --yes`.
+- [ ] Confirm deployment uses the centralized ECR image.
+- [ ] Confirm stack deploy succeeds.
+- [ ] Confirm stack outputs include a testable webhook endpoint.
+- [ ] Confirm deployed task starts successfully.
+
+### Deployed Stack Tests
+
+- [ ] Run `npm run test:dev -- --profile <bucketless-profile>` if compatible with the selected profile.
+- [ ] Run deployed health-only test if full test suite requires bucket-configured assumptions.
+- [ ] Send a Benchling entry event to the deployed bucketless stack.
+- [ ] Verify the entry event does not auto-create a package.
+- [ ] Verify logs show an expected bucketless skip or no-op outcome, not an error.
+- [ ] Test a notebook entry with one linked package in an accessible bucket.
+- [ ] Verify the linked package is found.
+- [ ] Test a notebook entry with no linked package.
+- [ ] Verify the no-linked-package outcome is clear.
+- [ ] Test a duplicate linked-package case if feasible.
+- [ ] Verify duplicate handling is clear and non-silent.
+- [ ] Test package browsing for a linked package if Canvas access is available.
+
+### Log and Diagnostics Review
+
+- [ ] Check ECS logs with `npx ts-node scripts/check-logs.ts --profile <bucketless-profile> --type=ecs --tail=100`.
+- [ ] Check API logs if webhook requests fail.
+- [ ] Confirm no startup errors mention missing `user_bucket` as fatal.
+- [ ] Confirm no invalid S3 ARN or empty bucket errors appear.
+- [ ] Confirm linked-package lookup logs distinguish found, none found, duplicate, and lookup failure where applicable.
+
+## Episode 10: Final Review and Handoff
+
+### Final Quality Gates
+
+- [ ] Run `npm test`.
+- [ ] Run `npm run test:integration` if changes affect deployed-stack contracts.
+- [ ] Run `npm run test:local` if runtime container behavior changed.
+- [ ] Run `npm run test:dev` or equivalent deployed bucketless verification.
+- [ ] Confirm IDE diagnostics are clear.
+- [ ] Confirm working tree only contains intended changes.
+
+### Backward Compatibility Review
+
+- [ ] Confirm existing bucket-configured profiles still validate.
+- [ ] Confirm existing bucket-configured secrets still parse.
+- [ ] Confirm existing bucket-configured deployments still synthesize.
+- [ ] Confirm existing bucket-configured entry events still create packages.
+- [ ] Confirm existing bucket-configured linked-package lookup still works.
+- [ ] Confirm existing package revision refresh behavior still works.
+
+### Release Readiness
+
+- [ ] Update changelog or release notes if required by project convention.
+- [ ] Document migration impact for existing users.
+- [ ] Document test stack name, profile, account, and region used for verification.
+- [ ] Document deployed endpoint test result.
+- [ ] Document any known limitations or deferred open questions.
+- [ ] Prepare PR summary with tests run.
+- [ ] Ensure no secrets, endpoints requiring redaction, or sensitive bucket/package details are exposed in committed docs.

--- a/spec/a10-bucketless/04-bucketless-next-steps-and-blockers.md
+++ b/spec/a10-bucketless/04-bucketless-next-steps-and-blockers.md
@@ -1,0 +1,90 @@
+# Bucketless Mode: Next Steps and Blockers
+
+**Branch**: a10-bucketless
+**Date**: 2026-07-03
+**Status**: Implemented locally, pushed, and opened for review
+**PR**: https://github.com/quiltdata/benchling-webhook/pull/396
+**Scope**: Post-implementation follow-up. No code.
+
+## Current State
+
+- Bucketless configuration is implemented across setup/config, secret creation and sync, validation, deployment parameter construction, and runtime config parsing.
+- Runtime entry and canvas event paths now skip default package creation when no package bucket is configured.
+- Linked package lookup now searches all discovered Quilt package-view buckets when running without a configured package bucket.
+- Linked package browse and metadata actions preserve the package bucket identity needed to inspect linked packages from other buckets.
+- Version was bumped from `0.18.0` to `0.19.0`.
+- `CHANGELOG.md` contains a `0.19.0` entry for bucketless support.
+
+## Completed Verification
+
+- `npm test` passed:
+  - TypeScript/Jest: 38 suites passed, 602 tests passed, 1 skipped.
+  - Python: 446 tests passed.
+- `npm run version:verify` passed after the version and changelog commits.
+- `git diff --check` passed before committing.
+- `npm run test:local` passed after local `.env` propagation was fixed:
+  - Docker dev image built successfully.
+  - Local container became healthy.
+  - Health, readiness, liveness, and webhook smoke checks passed.
+  - Summary: 8/8 tests passed.
+
+## Known Blockers
+
+1. A real bucketless AWS stack has not been deployed.
+   - No bucketless deployment profile or target stack was specified for this work.
+   - Deploying would create or update real AWS resources, so it should be done only against an explicitly selected profile/account.
+   - Impact: CloudFormation/ECS behavior is implemented and unit-tested where covered, but not yet validated in a live bucketless stack.
+
+2. Cross-bucket package discovery depends on Athena package-view availability and permissions.
+   - Bucketless lookup discovers buckets from `information_schema.tables` entries ending in `_packages-view`.
+   - Runtime IAM and Athena permissions must allow listing/querying the relevant package views.
+   - Impact: bucketless linked-package search may be incomplete in environments where accessible package views are missing, stale, or not queryable by the task role.
+
+## Next Steps
+
+1. Review and merge PR #396 after code review and CI pass.
+
+2. Prepare a bucketless test profile.
+   - Select the AWS account, region, and Benchling tenant to use.
+   - Configure the profile without `packages.bucket`.
+   - Ensure required Benchling secret fields are present.
+   - Ensure local `.env` contains `PACKAGING_REQUEST_QUEUE_URL` when running local smoke tests.
+
+3. Deploy a bucketless dev stack.
+   - Use the project deploy script with the selected profile.
+   - Confirm the deployment plan clearly reports bucketless mode.
+   - Confirm CloudFormation parameters accept the empty package bucket value.
+   - Confirm ECS task startup succeeds with a secret that omits `user_bucket`.
+
+4. Run deployed validation.
+   - Health and readiness checks should pass once required non-bucket settings are present.
+   - Entry created/updated events should return an accepted skipped result and must not enqueue default package creation.
+   - Canvas initialization/update flows should render bucketless-safe content and must not imply a default package exists.
+   - Linked package sections should still resolve and display packages from accessible package-view buckets.
+
+5. Validate cross-bucket linked package browsing.
+   - Use a Benchling entry linked to packages in at least two different Quilt buckets.
+   - Confirm linked package buttons preserve bucket identity.
+   - Confirm file browsing and metadata views read from the selected linked package's bucket.
+   - Confirm duplicate package names in different buckets remain distinguishable enough for users and logs.
+
+6. Validate package revision refresh behavior.
+   - Send package revision events from a bucket that is not a configured default bucket.
+   - Confirm bucketless deployments do not filter those events out solely because the event bucket differs from a configured bucket.
+   - Confirm canvas refresh reads package content from the event bucket.
+
+7. Decide whether additional documentation is required before release.
+   - README/setup guidance may need an explicit bucketless setup example.
+   - Operational docs may need to explain that bucketless mode disables default notebook-entry package creation.
+   - Troubleshooting docs may need to explain Athena package-view discovery requirements.
+
+8. After merge, create the release tag using the project script.
+   - Use `npm run version:tag` for a release tag after the branch is merged and the working tree is clean.
+   - Use `npm run version:tag:dev` only if a dev prerelease/test image is intended first.
+
+## Open Questions
+
+1. Which AWS profile/account should own the first bucketless test stack?
+2. Should bucketless mode be documented as generally available in `README.md`, or kept as release-note-only until deployed validation is complete?
+3. Should duplicate linked packages across buckets be shown with explicit bucket labels in the Canvas UI, or is preserving bucket context in buttons/logs sufficient for the first release?
+4. Should bucketless smoke tests assert linked-package discovery explicitly, beyond the current webhook skip responses?

--- a/spec/a10-bucketless/05-iceberg-search.md
+++ b/spec/a10-bucketless/05-iceberg-search.md
@@ -1,0 +1,101 @@
+# Bucketless Linked-Package Search via Iceberg Tables
+
+**Date**: 2026-07-04
+**Status**: Proposed
+
+## Problem
+
+The current [bucketless linked-package search](04-bucketless-next-steps-and-blockers.md) uses an expensive fanout:
+
+1. Lists all `{bucket}_packages-view` tables from Athena's `information_schema`
+2. Fans out N concurrent Athena queries (up to 12 threads, one per bucket)
+3. Each query uses `json_extract_scalar(user_meta, '$.key')` — raw JSON string parsing on the old parquet-backed views
+4. Each query has a tight 10-second timeout
+5. Risks hitting Athena's concurrent-DDL quota (20 per account)
+
+This is slow, brittle, and doesn't scale to deployments with many buckets.
+
+## Proposal
+
+Replace the concurrent fanout with a **single Athena query** against the per-bucket Iceberg tables that the Quilt Platform already maintains.
+
+### Background: Per-Bucket Iceberg Tables
+
+The Quilt Platform 1.70.0+ maintains per-bucket Iceberg tables in a dedicated Glue database (`QUILT_ICEBERG_GLUE_DB`):
+
+| Iceberg table | Columns | Analogous to |
+|---|---|---|
+| `{bucket}_package_manifest` | `top_hash`, `message`, `metadata` (STRUCT) | `_manifests` |
+| `{bucket}_package_revision` | `pkg_name`, `timestamp`, `top_hash` | `_packages` |
+| `{bucket}_package_tag` | `pkg_name`, `tag_name`, `top_hash` | `_packages` (named refs) |
+
+Key advantage: `metadata` is a **native Athena STRUCT** column, not a raw JSON string. Querying `metadata.experiment_id` is schema-native — no `json_extract_scalar` overhead.
+
+### Approach: Single UNION ALL Query
+
+When the webhook is configured with an Iceberg database name (new config: `QUILT_ICEBERG_DATABASE`), the bucketless search path:
+
+1. Lists all `{bucket}_package_manifest` tables from the Iceberg database via `information_schema.tables`
+2. Builds a **single Athena query** that joins `package_revision` ↔ `package_manifest` via `top_hash`, UNION ALL across all buckets
+3. Filters on `metadata.{key}` as a STRUCT field access
+4. Returns the merged result — one Athena call, one result set
+
+#### SQL shape
+
+```sql
+SELECT r.pkg_name, r.timestamp, m.message, m.metadata, '{bucket_a}' AS bucket
+FROM "{iceberg_db}"."{bucket_a}_package_revision" r
+JOIN "{iceberg_db}"."{bucket_a}_package_manifest" m ON r.top_hash = m.top_hash
+WHERE m.metadata.{key} = '{value}'
+  AND r.pkg_name IN (SELECT pkg_name FROM "{iceberg_db}"."{bucket_a}_package_tag" WHERE tag_name = 'latest')
+
+UNION ALL
+
+SELECT r.pkg_name, r.timestamp, m.message, m.metadata, '{bucket_b}' AS bucket
+FROM "{iceberg_db}"."{bucket_b}_package_revision" r
+JOIN "{iceberg_db}"."{bucket_b}_package_manifest" m ON r.top_hash = m.top_hash
+WHERE m.metadata.{key} = '{value}'
+  AND r.pkg_name IN (SELECT pkg_name FROM "{iceberg_db}"."{bucket_b}_package_tag" WHERE tag_name = 'latest')
+```
+
+### Fallback
+
+If `QUILT_ICEBERG_DATABASE` is not set, fall back to the existing `_packages-view` fanout. This maintains backward compatibility with deployments that don't have Iceberg tables (pre-1.70.0).
+
+### Performance Analysis
+
+| Factor | Current fanout (parquet views) | Proposed (Iceberg) |
+|---|---|---|
+| Athena queries | N (one per bucket) | 1 |
+| Metadata access | `json_extract_scalar` (parse JSON per row) | `metadata.{key}` (STRUCT, schema-native) |
+| Scan type | Full table scan (parquet) | Iceberg partition pruning |
+| Startup overhead | N × Athena query startup | 1 × Athena query startup |
+| Concurrency risk | Hits DDL quota at 20+ buckets | One query, no quota risk |
+| Timeout model | 10s per bucket (any slow bucket fails) | Single configurable timeout |
+
+**Estimated improvement**: 10–50× faster for typical multi-bucket deployments, and more reliable (no partial failures).
+
+### Config Changes
+
+```python
+# config.py — new optional property
+quilt_iceberg_database: Optional[str]  # from QUILT_ICEBERG_DATABASE env var
+```
+
+### Implementation Plan
+
+1. **`config.py`**: Add `quilt_iceberg_database` property reading `QUILT_ICEBERG_DATABASE`
+2. **`package_query.py`**:
+   - Accept `iceberg_database` in `__init__`
+   - Add `_list_iceberg_manifest_buckets()` — discover tables from Iceberg Glue DB
+   - Add `_find_unique_packages_in_iceberg()` — single UNION ALL query across all bucket manifests
+   - Add `_packages_selected_from_iceberg()` — build the per-bucket subquery
+   - Modify `_find_unique_packages_in_all_buckets()` (or `find_unique_packages()`) to prefer Iceberg path
+3. **Tests**: Add bucketless + Iceberg test cases
+
+### Open Questions
+
+1. Should we query `package_revision` (all revisions) and filter by `package_tag WHERE tag_name = 'latest'`, or query `package_tag` directly and join through `package_revision`? The former returns one row per revision; the latter returns only the latest. The current `_packages-view` uses `timestamp = 'latest'` — analog: filter through `package_tag`.
+2. What happens if a bucket has Iceberg tables but some are empty/stale? The UNION ALL query should handle empty result sets gracefully (they contribute zero rows).
+3. Should we make the Iceberg query timeout configurable? The current 30s default should be fine for a single query.
+4. Can we reduce table listing overhead by caching the Iceberg table list? Tables change infrequently (on bucket add/remove) — a 5-minute TTL cache would be safe.

--- a/spec/a10-bucketless/06-iceberg-parameter-audit.md
+++ b/spec/a10-bucketless/06-iceberg-parameter-audit.md
@@ -1,0 +1,342 @@
+# Iceberg Parameter Propagation Audit
+
+**Date**: 2026-07-06
+**Status**: Follow-up specification
+**Scope**: Documents what was implemented after [05-iceberg-search.md](05-iceberg-search.md), what is incomplete, and what must be fixed before this path is considered deployable.
+
+## Summary
+
+Spec 05 correctly identified `QUILT_ICEBERG_DATABASE` as the runtime switch for the faster bucketless linked-package search, but it did not specify how that value is discovered, stored in profile configuration, transformed into stack configuration, passed through deployment, granted IAM access, or verified.
+
+The current implementation partially wires the value into runtime and CloudFormation, then patches deployment with an untyped profile read. That makes the path fragile:
+
+1. The container can run without an Iceberg database even when the Quilt stack has one.
+2. Setup and stack inference do not populate the value.
+3. Typed config transforms drop the value.
+4. IAM grants do not cover the Iceberg Glue database or the Glue action now used to list tables.
+5. Runtime errors can report the wrong failing service or database.
+6. The Iceberg SQL path still has correctness risks independent of parameter passing.
+
+This spec defines the required behavior and audit findings only. It does not prescribe code-level implementation.
+
+## What Was Implemented
+
+### Runtime Configuration
+
+The Python container now has a runtime setting named `quilt_iceberg_database`, sourced from the `QUILT_ICEBERG_DATABASE` environment variable.
+
+When this value is present and the package bucket is not configured, bucketless linked-package search chooses the Iceberg query path instead of the legacy all-bucket `_packages-view` fanout.
+
+### Runtime Search Path
+
+The Iceberg search path now:
+
+1. Uses the Glue API to list tables in the configured Iceberg database.
+2. Treats tables ending in `_package_manifest` as searchable bucket manifests.
+3. Builds one `UNION ALL` Athena query across those buckets.
+4. Joins per-bucket `package_revision`, `package_manifest`, and `package_tag` tables.
+5. Filters on native Iceberg metadata fields instead of JSON string extraction.
+6. Returns the same broad result shape as the existing linked-package search path.
+
+### CloudFormation Parameter
+
+The CDK stack now defines an optional `IcebergDatabase` CloudFormation parameter.
+
+The Fargate service construct accepts an optional Iceberg database value and passes it to the task environment as `QUILT_ICEBERG_DATABASE`.
+
+### Deployment Hack
+
+The deploy command currently passes the `IcebergDatabase` CloudFormation parameter by reading `config.quilt.icebergDatabase` through an untyped cast.
+
+This was added as a direct deployment patch. It does not make `icebergDatabase` a properly propagated profile, stack, wizard, or inference field.
+
+### Tests
+
+Python tests were added for the basic Iceberg runtime path:
+
+1. Bucketless mode uses Iceberg when an Iceberg database is configured.
+2. Bucketless mode falls back to fanout when no Iceberg database is configured.
+3. Bucket-specific mode does not use the Iceberg path.
+4. Empty Iceberg table discovery returns no linked packages.
+5. The generated SQL contains the expected Iceberg table references.
+6. Multiple matched packages can be represented in the returned result.
+
+## What 05 Did Not Specify
+
+Spec 05 did not define the authoritative source of the Iceberg database value.
+
+It did not specify whether the value comes from:
+
+1. A Quilt CloudFormation output.
+2. A Quilt CloudFormation resource physical ID.
+3. A setup wizard discovery step.
+4. A profile field.
+5. A deploy CLI option.
+6. A manual config edit.
+
+It did not specify how the value flows through:
+
+1. `ProfileConfig`
+2. profile JSON schema validation
+3. setup wizard stack query results
+4. stack inference
+5. profile building
+6. `profileToStackConfig`
+7. `StackConfig`
+8. CDK stack construction
+9. CloudFormation parameters
+10. ECS task environment variables
+11. local `xdg-launch` environment variables
+
+It did not specify the IAM implications of listing and querying Iceberg tables in a different Glue database.
+
+It did not specify the deploy-time validation or operator-facing display needed to prove the fast path is active.
+
+## Current Gaps
+
+### Profile And Schema
+
+`QuiltConfig` has an optional `icebergDatabase` field, but the profile JSON schema does not include it under `quilt.properties`.
+
+Expected behavior:
+
+1. `quilt.icebergDatabase` is a supported optional profile field.
+2. The schema accepts and validates it.
+3. Unknown-field handling must not be the reason this value appears to work.
+4. Existing profiles without the field remain valid.
+
+### Stack Configuration
+
+`StackConfig` does not include `quilt.icebergDatabase`.
+
+`profileToStackConfig` does not copy `profile.quilt.icebergDatabase`.
+
+Expected behavior:
+
+1. `icebergDatabase` is part of the typed stack configuration when present.
+2. CDK receives the value through the same typed path as catalog, database, queue URL, region, workgroup, and managed policy ARNs.
+3. Deploy must not recover the value through an `unknown` cast.
+
+### Setup And Discovery
+
+`StackQueryResult` does not include an Iceberg database field.
+
+The profile builder does not copy a discovered Iceberg database into `config.quilt.icebergDatabase`.
+
+Stack resource discovery does not include the Quilt `IcebergDatabase` resource.
+
+The inference command has broad database-output matching that can confuse database-like outputs if more outputs are introduced.
+
+Expected behavior:
+
+1. Discovery should prefer an explicit Quilt stack resource or output that represents the Iceberg Glue database.
+2. If the Quilt stack has a logical `IcebergDatabase` resource, its physical resource ID should be captured as `quilt.icebergDatabase`.
+3. If a future Quilt stack output provides the same value, that output should be matched by exact name, not by broad substring matching.
+4. Setup should display the discovered Iceberg database when present.
+5. Setup should leave the field absent when the Quilt stack does not expose Iceberg resources.
+6. A manually configured `quilt.icebergDatabase` must be preserved when reusing an existing profile unless a newer discovery result intentionally replaces it.
+
+### Deploy Parameter Passing
+
+The deploy command currently builds `IcebergDatabase` using an untyped cast against `config.quilt`.
+
+Expected behavior:
+
+1. Deployment uses the typed stack or profile config field.
+2. The deploy plan displays the Iceberg database when present.
+3. A deployment intended to test bucketless Iceberg search must show a non-empty Iceberg database before CDK deploy starts.
+4. The CloudFormation parameter, stack default, Fargate prop, and ECS environment variable must all receive the same value.
+5. There must be no separate deploy-only path that can drift from setup, profile validation, or CDK synthesis.
+
+### Local Launch
+
+The local `xdg-launch` environment builder does not pass `QUILT_ICEBERG_DATABASE`.
+
+Expected behavior:
+
+1. Local launches use the same profile value as deployed ECS tasks.
+2. Local bucketless smoke tests can exercise the Iceberg path without hand-exporting the variable.
+
+### IAM
+
+The Fargate task role currently grants Glue access for the regular Quilt/Athena database only.
+
+The runtime Iceberg discovery path calls Glue `GetTables`, but the inline policy includes `GetDatabase`, `GetTable`, and `GetPartitions`, not `GetTables`.
+
+Expected behavior:
+
+1. When `quilt.icebergDatabase` is set, the task role can call Glue APIs needed to list and query the Iceberg database.
+2. Required Glue actions include the table-listing action used by runtime discovery.
+3. Glue resources cover the catalog, the regular Quilt database, the Iceberg database, and the tables under both databases as needed.
+4. Athena execution permissions remain tied to the configured Athena workgroup.
+5. If a Quilt-managed Athena policy is attached, the implementation must verify whether it covers the Iceberg Glue database. If it does not, the webhook stack must add the missing grants.
+6. The deployed role must not rely on broad accidental permissions from the deploying user or a local profile.
+
+### Runtime Query Correctness
+
+The current Iceberg query joins `package_tag` by package name and tag name, but does not require the revision top hash to match the latest tag top hash.
+
+Expected behavior:
+
+1. The Iceberg path returns only the latest package revision for each package.
+2. The query must constrain the selected revision to the `latest` tag's top hash.
+3. The query must not return historical revisions just because the package has a latest tag.
+
+The current metadata result handling assumes the selected Iceberg metadata value can be parsed as JSON.
+
+Expected behavior:
+
+1. The query result must provide metadata in a format that the Python result builder can parse deterministically.
+2. Native Athena `STRUCT` values must either be serialized intentionally or handled by a parser designed for Athena's returned representation.
+3. Failed metadata parsing must not hide a successful package match.
+
+The metadata key is interpolated as a STRUCT field name.
+
+Expected behavior:
+
+1. Metadata keys used in Iceberg SQL must be validated before query construction.
+2. Invalid or unsupported metadata keys must produce a clear configuration error.
+3. The implementation must not treat arbitrary user input as a SQL identifier.
+
+### Error Reporting
+
+Current AccessDenied rewriting reports an Athena StartQueryExecution problem on the regular Athena database even when the failure may be Glue `GetTables`, Glue table access, the Iceberg database, or another call.
+
+Expected behavior:
+
+1. Glue access failures identify Glue and the target database.
+2. Athena execution failures identify Athena and the target workgroup.
+3. Missing Iceberg configuration is reported separately from no linked packages found.
+4. Permission failures must not be converted into "no linked packages found."
+5. Canvas warnings should tell the operator which profile/stack parameter is missing or which IAM permission is missing.
+
+## Required Fixes
+
+### Fix The Configuration Contract
+
+`quilt.icebergDatabase` must be the single source of truth for this feature in profile configuration.
+
+The value must be optional. Absence means the deployment does not use Iceberg-backed bucketless search and may use the legacy fallback.
+
+Presence means the deployment intends to use Iceberg-backed bucketless search and must have matching runtime configuration and IAM.
+
+### Fix Discovery And Profile Persistence
+
+Setup and inference must discover the Iceberg database from the Quilt stack when available.
+
+Discovery must use exact resource or output names. It must not rely on generic output names containing the word `Database`.
+
+The profile builder must persist the discovered value into `quilt.icebergDatabase`.
+
+Existing manually configured values must be preserved unless a deterministic discovery source replaces them.
+
+### Fix Typed Propagation
+
+The typed path must carry `quilt.icebergDatabase` from profile to stack:
+
+1. Profile config
+2. Profile schema
+3. Stack query result
+4. Profile builder
+5. Stack config
+6. Config transform
+7. CDK stack
+8. Fargate service
+9. ECS environment
+10. Local launch environment
+
+Deploy must stop using the untyped `unknown` cast.
+
+### Fix IAM
+
+The ECS task role must have the Glue permissions needed for both the regular Quilt database and the Iceberg database.
+
+At minimum, the role must be able to:
+
+1. Read the Glue catalog.
+2. Read the regular Quilt database and tables needed by the legacy path.
+3. Read the Iceberg database.
+4. List tables in the Iceberg database.
+5. Read Iceberg package tables used by linked-package search.
+
+The required permissions must be covered by tests at the synthesized CloudFormation/template level.
+
+### Fix Runtime SQL Semantics
+
+The Iceberg query must select only the latest tagged package revision.
+
+The metadata result must be shaped so the Python result builder can reliably attach package metadata.
+
+Metadata field identifiers must be validated before query construction.
+
+### Fix Operator Visibility
+
+Deployment output must show whether Iceberg search is enabled.
+
+The Canvas app output must distinguish:
+
+1. Iceberg enabled and linked packages found.
+2. Iceberg enabled and no linked packages found.
+3. Iceberg disabled, using legacy fallback.
+4. Iceberg configured but inaccessible.
+5. Iceberg configured but missing required tables.
+
+The deployed revision shown in Canvas must be enough to confirm the user is testing the intended image/tag.
+
+## Test Requirements
+
+### TypeScript Unit Tests
+
+Add coverage that proves:
+
+1. Profile schema accepts `quilt.icebergDatabase`.
+2. `profileToStackConfig` preserves `quilt.icebergDatabase`.
+3. Stack inference extracts the Iceberg database from the intended Quilt stack resource or exact output.
+4. Profile builders persist the discovered Iceberg database.
+5. Deploy parameter construction uses the typed value and does not require an untyped cast.
+6. CDK synthesis sets `QUILT_ICEBERG_DATABASE` on the ECS task.
+7. CDK synthesis grants Glue access for the Iceberg database and includes the table-listing action.
+8. Local launch environment includes `QUILT_ICEBERG_DATABASE` when configured.
+
+### Python Unit Tests
+
+Add coverage that proves:
+
+1. Bucketless search uses Iceberg only when an Iceberg database is configured.
+2. The generated query constrains latest tag top hash correctly.
+3. Metadata returned from Iceberg is parsed consistently.
+4. Invalid metadata keys are rejected before query execution.
+5. Glue access errors are reported as Glue access errors.
+6. Athena execution errors are reported as Athena execution errors.
+7. Permission errors do not become empty-result success responses.
+
+### Integration And Deployment Tests
+
+Add a testable stack deployment path that proves:
+
+1. The selected profile contains a non-empty `quilt.icebergDatabase`.
+2. The deployed CloudFormation stack has the expected `IcebergDatabase` parameter value.
+3. The ECS task definition has `QUILT_ICEBERG_DATABASE` set.
+4. The ECS task role can list Iceberg manifest tables.
+5. Bucketless Canvas refresh finds a known linked package without using the legacy fanout path.
+
+## Acceptance Criteria
+
+This feature is complete only when all of the following are true:
+
+1. A profile generated from a Quilt stack with Iceberg resources contains `quilt.icebergDatabase`.
+2. A deployment from that profile sets the `IcebergDatabase` CloudFormation parameter without any untyped config cast.
+3. The running container receives `QUILT_ICEBERG_DATABASE`.
+4. The task role can call Glue table-listing APIs against the Iceberg database.
+5. The task role can query the Iceberg package tables through Athena.
+6. Bucketless linked-package refresh uses a single Iceberg query and does not fan out across `_packages-view` tables.
+7. Linked packages are found for a known Benchling entry that has packages in accessible Quilt buckets.
+8. A permission problem produces an actionable warning, not a false "no linked packages found" result.
+9. The legacy fanout remains available only for deployments with no configured Iceberg database.
+10. Unit and integration tests cover config propagation, IAM, runtime query correctness, and deploy-time observability.
+
+## Deployment Blocker
+
+Do not treat the current Iceberg parameter implementation as production-ready.
+
+The current deploy-side cast can make one deployment appear to work, but it bypasses the typed configuration system and does not solve setup discovery, profile validation, local launch, IAM, or SQL correctness. A real fix must move the Iceberg database through the same configuration and deployment conventions used by the rest of the Quilt service settings.

--- a/spec/a10-bucketless/README.md
+++ b/spec/a10-bucketless/README.md
@@ -1,0 +1,3 @@
+# A10 Bucketless
+
+Spec workspace for the A10 bucketless workstream.

--- a/test/benchling-webhook-stack.test.ts
+++ b/test/benchling-webhook-stack.test.ts
@@ -293,6 +293,33 @@ describe("BenchlingWebhookStack", () => {
         });
     });
 
+    test("passes Iceberg database parameter to all ECS containers", () => {
+        const taskDefinitions = template.findResources("AWS::ECS::TaskDefinition");
+        const taskDefinition = Object.values(taskDefinitions)[0] as any;
+        const containerDefinitions = taskDefinition.Properties.ContainerDefinitions;
+
+        for (const container of containerDefinitions) {
+            expect(container.Environment).toEqual(
+                expect.arrayContaining([
+                    {
+                        Name: "QUILT_ICEBERG_DATABASE",
+                        Value: { Ref: "IcebergDatabase" },
+                    },
+                ]),
+            );
+        }
+    });
+
+    test("grants Glue access for Iceberg table discovery and package tables", () => {
+        const policies = template.findResources("AWS::IAM::Policy");
+        const policyText = JSON.stringify(policies);
+
+        expect(policyText).toContain("glue:GetTables");
+        expect(policyText).toContain("IcebergDatabase");
+        expect(policyText).toContain("database/");
+        expect(policyText).toContain("table/");
+    });
+
     test("configures auto-scaling", () => {
         template.hasResourceProperties("AWS::ApplicationAutoScaling::ScalableTarget", {
             MinCapacity: 2,
@@ -324,6 +351,7 @@ describe("BenchlingWebhookStack", () => {
                     database: "test_database",
                     queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
                     region: "us-east-1",
+                    icebergDatabase: "iceberg_database",
                 },
             });
             const stack = new BenchlingWebhookStack(app, "TestStack", {
@@ -345,6 +373,9 @@ describe("BenchlingWebhookStack", () => {
             });
             testTemplate.hasParameter("PackagerQueueUrl", {
                 Default: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+            });
+            testTemplate.hasParameter("IcebergDatabase", {
+                Default: "iceberg_database",
             });
         });
 

--- a/test/config-transform.test.ts
+++ b/test/config-transform.test.ts
@@ -25,6 +25,7 @@ describe("config-transform", () => {
                     region: "us-east-1",
                     bucketWritePolicyArn: "arn:aws:iam::123456789012:policy/test-bucket-write-policy",
                     athenaUserPolicyArn: "arn:aws:iam::123456789012:policy/test-athena-policy",
+                    icebergDatabase: "iceberg_db",
                 },
                 packages: {
                     bucket: "test-bucket",
@@ -297,6 +298,7 @@ describe("config-transform", () => {
                     region: "us-east-1",
                     bucketWritePolicyArn: "arn:aws:iam::123456789012:policy/test-bucket-write-policy",
                     athenaUserPolicyArn: "arn:aws:iam::123456789012:policy/test-athena-policy",
+                    icebergDatabase: "iceberg_db",
                 },
                 packages: {
                     bucket: "test-bucket",
@@ -332,6 +334,7 @@ describe("config-transform", () => {
                     region: "us-east-1",
                     bucketWritePolicyArn: "arn:aws:iam::123456789012:policy/test-bucket-write-policy",
                     athenaUserPolicyArn: "arn:aws:iam::123456789012:policy/test-athena-policy",
+                    icebergDatabase: "iceberg_db",
                 },
                 deployment: {
                     region: "us-east-1",
@@ -429,6 +432,7 @@ describe("config-transform", () => {
 
             expect(stackConfig.quilt.bucketWritePolicyArn).toBeUndefined();
             expect(stackConfig.quilt.athenaUserPolicyArn).toBeUndefined();
+            expect(stackConfig.quilt.icebergDatabase).toBeUndefined();
             expect(stackConfig.deployment.imageTag).toBeUndefined();
             expect(stackConfig.deployment.vpc).toBeUndefined();
             expect(stackConfig.deployment.stackName).toBeUndefined();

--- a/test/config-transform.test.ts
+++ b/test/config-transform.test.ts
@@ -49,6 +49,42 @@ describe("config-transform", () => {
             expect(result.errors).toHaveLength(0);
         });
 
+        it("should pass validation for bucketless package configuration", () => {
+            const validConfig: ProfileConfig = {
+                benchling: {
+                    tenant: "test-tenant",
+                    clientId: "client_123",
+                    secretArn: "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret",
+                    appDefinitionId: "app_456",
+                },
+                quilt: {
+                    catalog: "quilt.example.com",
+                    database: "quilt_catalog",
+                    queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+                    region: "us-east-1",
+                },
+                packages: {
+                    prefix: "benchling",
+                    metadataKey: "experiment_id",
+                },
+                deployment: {
+                    region: "us-east-1",
+                    imageTag: "latest",
+                },
+                _metadata: {
+                    version: "0.10.0",
+                    createdAt: "2025-12-24T00:00:00Z",
+                    updatedAt: "2025-12-24T00:00:00Z",
+                    source: "wizard",
+                },
+            };
+
+            const result = validateStackConfig(validConfig);
+
+            expect(result.isValid).toBe(true);
+            expect(result.errors).toHaveLength(0);
+        });
+
         it("should fail validation when benchling.secretArn is missing", () => {
             const invalidConfig: ProfileConfig = {
                 benchling: {

--- a/test/integration/xdg-launch-pure-functions.test.ts
+++ b/test/integration/xdg-launch-pure-functions.test.ts
@@ -333,12 +333,18 @@ describe("XDG Launch Pure Functions - Integration", () => {
                     resourceType: "AWS::IAM::Policy",
                     resourceStatus: "CREATE_COMPLETE",
                 },
+                IcebergDatabase: {
+                    physicalResourceId: "iceberg_db",
+                    resourceType: "AWS::Glue::Database",
+                    resourceStatus: "CREATE_COMPLETE",
+                },
             };
 
             const discovered: DiscoveredQuiltResources = extractQuiltResources(mockResources);
 
             expect(discovered.athenaUserWorkgroup).toBe("my-user-workgroup");
             expect(discovered.athenaUserPolicyArn).toBe("my-user-policy-ABCDEF");
+            expect(discovered.icebergDatabase).toBe("iceberg_db");
         });
 
         it("should handle empty resource map gracefully", () => {

--- a/test/sync-secrets.test.ts
+++ b/test/sync-secrets.test.ts
@@ -203,4 +203,79 @@ describe("sync-secrets CLI", () => {
         const secretPayload = JSON.parse(updateCalls[0].SecretString as string);
         expect(secretPayload.workflow).toBe("custom-workflow");
     });
+
+    test("dry-run never prints the plaintext client secret", async () => {
+        const profileName = "default";
+        const existingSecretArn =
+            "arn:aws:secretsmanager:us-east-1:123456789012:secret:existing-secret-abc123";
+        const timestamp = new Date().toISOString();
+        const plaintextSecret = "super-secret-value";
+
+        const profileConfig: ProfileConfig = {
+            benchling: {
+                tenant: "test-tenant",
+                clientId: "client-xyz",
+                clientSecret: plaintextSecret,
+                secretArn: existingSecretArn,
+                appDefinitionId: "app_123",
+            },
+            quilt: {
+                stackArn: "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/abc123",
+                catalog: "quilt.example.com",
+                database: "quilt_db",
+                queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/queue/test",
+                region: "us-east-1",
+            },
+            packages: {
+                bucket: "packages-bucket",
+                prefix: "benchling",
+                metadataKey: "experiment_id",
+            },
+            deployment: {
+                region: "us-east-1",
+                imageTag: "latest",
+            },
+            logging: {
+                level: "INFO",
+            },
+            security: {
+                enableVerification: true,
+                webhookAllowList: "",
+            },
+            _metadata: {
+                version: "0.7.0-test",
+                createdAt: timestamp,
+                updatedAt: timestamp,
+                source: "cli",
+            },
+        };
+
+        mockStorage.writeProfile(profileName, profileConfig);
+
+        sendMock.mockImplementation(async (command) => {
+            if (command instanceof DescribeSecretCommand) {
+                return { ARN: existingSecretArn };
+            }
+            if (command instanceof UpdateSecretCommand || command instanceof CreateSecretCommand) {
+                throw new Error("Dry-run must not write to Secrets Manager");
+            }
+            throw new Error(`Unexpected command: ${command.constructor.name}`);
+        });
+
+        const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+        try {
+            await syncSecretsToAWS({
+                profile: profileName,
+                region: "us-east-1",
+                dryRun: true,
+                configStorage: mockStorage,
+            });
+
+            const output = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+            expect(output).not.toContain(plaintextSecret);
+            expect(output).toContain("***REDACTED***");
+        } finally {
+            logSpy.mockRestore();
+        }
+    });
 });

--- a/test/unit/config-types.test.ts
+++ b/test/unit/config-types.test.ts
@@ -4,7 +4,8 @@
  * Tests the QuiltConfig interface updates for service environment variables.
  */
 
-import { QuiltConfig } from "../../lib/types/config";
+import Ajv from "ajv";
+import { ProfileConfigSchema, QuiltConfig } from "../../lib/types/config";
 
 describe("QuiltConfig", () => {
     test("stackArn is optional for explicit service configuration", () => {
@@ -54,5 +55,51 @@ describe("QuiltConfig", () => {
         };
         expect(config).toBeDefined();
         expect(config.athenaUserWorkgroup).toBe("quilt-workgroup");
+    });
+
+    test("icebergDatabase can be provided for bucketless Iceberg search", () => {
+        const config: QuiltConfig = {
+            catalog: "quilt.example.com",
+            database: "quilt_db",
+            queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/queue",
+            region: "us-east-1",
+            icebergDatabase: "iceberg_db",
+        };
+        expect(config.icebergDatabase).toBe("iceberg_db");
+    });
+
+    test("profile schema accepts optional icebergDatabase", () => {
+        const ajv = new Ajv({ allErrors: true, strict: false });
+        const validate = ajv.compile(ProfileConfigSchema);
+        const valid = validate({
+            quilt: {
+                catalog: "quilt.example.com",
+                database: "quilt_db",
+                queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/queue",
+                region: "us-east-1",
+                icebergDatabase: "iceberg_db",
+            },
+            benchling: {
+                tenant: "test-tenant",
+                clientId: "client_123",
+                appDefinitionId: "app_123",
+            },
+            packages: {
+                prefix: "benchling",
+                metadataKey: "experiment_id",
+            },
+            deployment: {
+                region: "us-east-1",
+            },
+            _metadata: {
+                version: "0.19.0",
+                createdAt: "2026-07-06T00:00:00Z",
+                updatedAt: "2026-07-06T00:00:00Z",
+                source: "wizard",
+            },
+        });
+
+        expect(validate.errors).toBeNull();
+        expect(valid).toBe(true);
     });
 });

--- a/test/unit/service-resolver.test.ts
+++ b/test/unit/service-resolver.test.ts
@@ -228,6 +228,40 @@ describe("resolveQuiltServices", () => {
         expect(services.athenaUserWorkgroup).toBe("user-wg");
     });
 
+    test("includes optional Iceberg database when available", async () => {
+        cfnMock.on(DescribeStacksCommand).resolves({
+            Stacks: [
+                mockStack([
+                    {
+                        OutputKey: "PackagerQueueUrl",
+                        OutputValue:
+                            "https://sqs.us-east-1.amazonaws.com/123456789012/queue",
+                    },
+                    {
+                        OutputKey: "UserAthenaDatabaseName",
+                        OutputValue: "quilt_catalog",
+                    },
+                    {
+                        OutputKey: "QuiltWebHost",
+                        OutputValue: "quilt.example.com",
+                    },
+                    {
+                        OutputKey: "IcebergDatabase",
+                        OutputValue: "iceberg_db",
+                    },
+                ]),
+            ],
+        });
+
+        const services = await resolveQuiltServices({
+            stackArn:
+                "arn:aws:cloudformation:us-east-1:123456789012:stack/QuiltStack/id",
+            mockCloudFormation: cfnMock as unknown as CloudFormationClient,
+        });
+
+        expect(services.icebergDatabase).toBe("iceberg_db");
+    });
+
     test("omits optional Athena metadata when not available", async () => {
         cfnMock.on(DescribeStacksCommand).resolves({
             Stacks: [

--- a/test/utils-stack-inference.test.ts
+++ b/test/utils-stack-inference.test.ts
@@ -84,6 +84,28 @@ describe("stack-inference utility", () => {
             expect(vars.QUILT_DATABASE).toBe("my_catalog_db");
         });
 
+        it("should extract Iceberg database from exact Iceberg output without replacing Quilt database", () => {
+            const stackDetails: StackDetails = {
+                outputs: [
+                    { OutputKey: "UserAthenaDatabaseName", OutputValue: "my_catalog_db" },
+                    { OutputKey: "IcebergDatabase", OutputValue: "iceberg_db" },
+                ],
+                parameters: [],
+            };
+
+            const vars = buildInferredConfig(
+                mockConfig,
+                "my-stack",
+                stackDetails,
+                "us-east-1",
+                "123456789012",
+                "https://catalog.example.com",
+            );
+
+            expect(vars.QUILT_DATABASE).toBe("my_catalog_db");
+            expect(vars.QUILT_ICEBERG_DATABASE).toBe("iceberg_db");
+        });
+
         it("should infer database from catalog name when not in outputs", () => {
             const stackDetails: StackDetails = {
                 outputs: [],


### PR DESCRIPTION
## Summary

- make the package bucket optional across setup/config/secrets/deploy paths
- skip default package creation for entry and canvas events when no bucket is configured
- search all Quilt package-view buckets for linked packages in bucketless mode and preserve bucket context for browsing/metadata
- bump package version to 0.19.0 and document the release notes

## Tests

- `npm test`
- `npm run version:verify`
- `npm run test:local` built and launched the Docker dev container, but webhook smoke checks failed because the local `dev` profile is degraded: `PACKAGING_REQUEST_QUEUE_URL is not configured`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the Quilt package bucket optional across setup, secret creation, deployment, and runtime, enabling \"bucketless\" deployments that skip default package creation for entry/canvas events and instead search all available Quilt package-view buckets when resolving linked packages.

- **Runtime guards** (`app.py`, `entry_packager.py`, `sqs_consumer.py`): every handler that would auto-create a package now returns a `202 SKIPPED` response when `s3_bucket_name` is empty; SQS consumer passes the event's actual bucket through to canvas refresh rather than filtering on a configured bucket.
- **Multi-bucket linked-package discovery** (`package_query.py`, `canvas.py`, `canvas_blocks.py`, `pagination.py`): in bucketless mode the Athena query enumerates all `*_packages-view` tables and merges results; browse/metadata button IDs now embed an optional `-bucket-{name}` segment so the correct `PackageFileFetcher` can be reconstructed on subsequent canvas interactions.
- **Configuration/deployment** (`lib/`, `bin/`): bucket made optional in `PackageConfig`, wizard parameter collection, profile builders, secret sync, and IAM policy synthesis; `configuration-validator.ts` updated but `validateConfig` in `lib/utils/config.ts` was not.

<h3>Confidence Score: 3/5</h3>

The bucket-configured path is unchanged and safe; the bucketless path has two defects that would silently produce wrong behavior for users with non-standard bucket names or who reach the legacy validateConfig function.

The encode/decode scheme for bucket names replaces '--' with '/' on decode, corrupting any S3 bucket name with consecutive hyphens. Separately, validateConfig in lib/utils/config.ts still rejects a missing quiltUserBucket even though its description was updated to call the field optional.

docker/src/pagination.py (encode/decode collision), lib/utils/config.ts (requiredUserFields still includes quiltUserBucket)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docker/src/pagination.py | Added encode/decode functions for bucket names and a new 5-tuple parse function; the decode_bucket_name function has a collision bug for bucket names containing '--', and the docstring for the new function was not updated. |
| lib/utils/config.ts | quiltUserBucket description updated to say 'Optional' but the field remains in the requiredUserFields array, meaning validateConfig() still errors when the bucket is absent. |
| docker/src/package_query.py | Extracted single-bucket query to _find_unique_packages_in_bucket; added _list_package_view_buckets for bucketless multi-bucket search; LIKE pattern uses unescaped _ wildcard (minor, corrected by Python endswith filter). |
| docker/src/canvas.py | Gracefully handles bucketless mode in markdown rendering and navigation buttons; adds _file_fetcher_for_bucket to create per-bucket fetchers when browsing linked packages across multiple buckets. |
| docker/src/app.py | Adds _bucketless_response helper and guards all packaging-trigger handlers to skip default package creation when s3_bucket_name is empty. |
| docker/src/canvas_blocks.py | Extended browser/metadata navigation button constructors to accept optional bucket_name; relies on the encode/decode scheme that has the -- collision risk. |
| docker/src/secrets_manager.py | user_bucket moved to an optional dataclass field with default None; removed from required-params validation lists. |
| docker/src/sqs_consumer.py | Bucket filter is now conditional on s3_bucket_name being set; passes parsed.bucket through to refresh_canvas_for_package_event in bucketless mode. |
| lib/fargate-service.ts | packageBucket is now optional; S3 IAM policy block wrapped in if(props.packageBucket) guard to avoid empty-ARN policy statements. |
| lib/configuration-validator.ts | quiltUserBucket removed from the required-fields list, correctly making it optional for bucketless deployments. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Webhook Event] --> B{s3_bucket_name set?}
    B -- Yes --> C[Publish SQS packaging request]
    B -- No --> D[Return 202 SKIPPED bucketless response]
    C --> E[SqsConsumer receives Quilt event]
    E --> F{s3_bucket_name set AND bucket mismatch?}
    F -- Yes --> G[Skip / delete message]
    F -- No --> H[refresh_canvas_for_package_event with parsed.bucket]
    I[Canvas button click] --> J{Action type?}
    J -- Browse/Update/Metadata default --> K{s3_bucket_name set?}
    K -- No --> D
    K -- Yes --> L[Use configured bucket]
    J -- Browse Linked --> M[parse button ID, extract bucket_name]
    M --> N[_file_fetcher_for_bucket bucket_name]
    N --> O{bucket_name matches default fetcher?}
    O -- Yes --> P[Reuse _package_file_fetcher]
    O -- No --> Q[Create new PackageFileFetcher for that bucket]
    R[PackageQuery.find_unique_packages] --> S{self.bucket set?}
    S -- Yes --> T[_find_unique_packages_in_bucket self.bucket]
    S -- No --> U[_list_package_view_buckets Athena information_schema]
    U --> V[For each bucket: _find_unique_packages_in_bucket]
    V --> W[Merge results sorted by bucket+name]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Webhook Event] --> B{s3_bucket_name set?}
    B -- Yes --> C[Publish SQS packaging request]
    B -- No --> D[Return 202 SKIPPED bucketless response]
    C --> E[SqsConsumer receives Quilt event]
    E --> F{s3_bucket_name set AND bucket mismatch?}
    F -- Yes --> G[Skip / delete message]
    F -- No --> H[refresh_canvas_for_package_event with parsed.bucket]
    I[Canvas button click] --> J{Action type?}
    J -- Browse/Update/Metadata default --> K{s3_bucket_name set?}
    K -- No --> D
    K -- Yes --> L[Use configured bucket]
    J -- Browse Linked --> M[parse button ID, extract bucket_name]
    M --> N[_file_fetcher_for_bucket bucket_name]
    N --> O{bucket_name matches default fetcher?}
    O -- Yes --> P[Reuse _package_file_fetcher]
    O -- No --> Q[Create new PackageFileFetcher for that bucket]
    R[PackageQuery.find_unique_packages] --> S{self.bucket set?}
    S -- Yes --> T[_find_unique_packages_in_bucket self.bucket]
    S -- No --> U[_list_package_view_buckets Athena information_schema]
    U --> V[For each bucket: _find_unique_packages_in_bucket]
    V --> W[Merge results sorted by bucket+name]
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `lib/utils/config.ts`, line 203-223 ([link](https://github.com/quiltdata/benchling-webhook/blob/cd90cac4efcf1c7ef5945430fdfd2842f6f7ca3e/lib/utils/config.ts#L203-L223)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`validateConfig` still treats `quiltUserBucket` as required despite the "Optional" description**

   `quiltUserBucket` remains in the `requiredUserFields` array, so the loop on line 215 pushes an error whenever the bucket is absent. The newly changed `helpText` reads "Optional. When omitted, bucketless mode…" but the code still produces `errors.push(...)` for that field, which sets `valid: false`. Any caller that uses the return value to gate a bucketless deployment would be incorrectly blocked. `lib/configuration-validator.ts` was correctly updated to remove the field from its required list; this utility function was not.


2. `docker/src/pagination.py`, line 61-84 ([link](https://github.com/quiltdata/benchling-webhook/blob/cd90cac4efcf1c7ef5945430fdfd2842f6f7ca3e/docker/src/pagination.py#L61-L84)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Docstring for `parse_browse_linked_button_id_with_bucket` describes the old 4-tuple return**

   The `Returns:` section still says "Tuple of (entry_id, package_name, page_number, page_size)" and the examples reference the old `parse_browse_linked_button_id` function instead of the new one. The actual return type is a 5-tuple `(entry_id, package_name, bucket_name, page_number, page_size)`. Doctests or documentation tooling that exercises these examples would fail.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["docs: update changelog for 0.19.0"](https://github.com/quiltdata/benchling-webhook/commit/cd90cac4efcf1c7ef5945430fdfd2842f6f7ca3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41727335)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->